### PR TITLE
Addition of PsychicStreamResponse & update to PsychicFileResponse.

### DIFF
--- a/src/ChunkPrinter.cpp
+++ b/src/ChunkPrinter.cpp
@@ -20,11 +20,11 @@ size_t ChunkPrinter::write(uint8_t c)
   //if we're full, send a chunk
   if (_pos == _length)
   {
-  _pos = 0;
-
-  err = _response->sendChunk(_buffer, _length);
-  if (err != ESP_OK)
-    return 0;
+    _pos = 0;
+    err = _response->sendChunk(_buffer, _length);
+	
+    if (err != ESP_OK)
+      return 0;
   }    
 
   _buffer[_pos] = c;
@@ -47,10 +47,10 @@ size_t ChunkPrinter::write(const uint8_t *buffer, size_t size)
     
     if (_pos == _length)
     {
-    _pos = 0;
+      _pos = 0;
 
-    if (_response->sendChunk(_buffer, _length) != ESP_OK)
-      return written;
+      if (_response->sendChunk(_buffer, _length) != ESP_OK)
+        return written;
     }
     written += blockSize; //Update if sent correctly.
   }

--- a/src/ChunkPrinter.cpp
+++ b/src/ChunkPrinter.cpp
@@ -1,0 +1,86 @@
+
+#include "ChunkPrinter.h"
+
+ChunkPrinter::ChunkPrinter(PsychicResponse *response, uint8_t *buffer, size_t len) :
+  _response(response),
+  _buffer(buffer),
+  _length(len),
+  _pos(0)
+{}
+
+ChunkPrinter::~ChunkPrinter()
+{
+  flush();
+}
+
+size_t ChunkPrinter::write(uint8_t c)
+{
+  esp_err_t err;
+  
+  //if we're full, send a chunk
+  if (_pos == _length)
+  {
+  _pos = 0;
+
+  err = _response->sendChunk(_buffer, _length);
+  if (err != ESP_OK)
+    return 0;
+  }    
+
+  _buffer[_pos] = c;
+  _pos++;
+  return 1;
+}
+
+size_t ChunkPrinter::write(const uint8_t *buffer, size_t size)
+{
+  esp_err_t err;
+  size_t written = 0;
+  
+  while (written < size)
+  {
+    size_t space = _length - _pos;
+    size_t blockSize = std::min(space, size - written);
+    
+    memcpy(_buffer + _pos, buffer + written, blockSize);
+    _pos += blockSize;
+    
+    if (_pos == _length)
+    {
+    _pos = 0;
+
+    if (_response->sendChunk(_buffer, _length) != ESP_OK)
+      return written;
+    }
+    written += blockSize; //Update if sent correctly.
+  }
+  return written;
+}
+
+void ChunkPrinter::flush()
+{
+  if (_pos)
+  {
+    _response->sendChunk(_buffer, _pos);
+    _pos = 0;
+  }
+}
+
+size_t ChunkPrinter::copyFrom(Stream &stream)
+{
+  size_t count = 0;
+
+  while (stream.available()){
+    
+    if (_pos == _length)
+    {
+      _response->sendChunk(_buffer, _length);
+      _pos = 0;
+    }
+    
+    size_t readBytes = stream.readBytes(_buffer + _pos, _length - _pos);
+    _pos += readBytes;
+    count += readBytes;
+  }
+  return count;
+}

--- a/src/ChunkPrinter.h
+++ b/src/ChunkPrinter.h
@@ -1,7 +1,6 @@
 #ifndef ChunkPrinter_h
 #define ChunkPrinter_h
 
-// #include "PsychicCore.h"
 #include "PsychicResponse.h"
 #include <Print.h>
 
@@ -14,43 +13,15 @@ class ChunkPrinter : public Print
     size_t _pos;
 
   public:
-    ChunkPrinter(PsychicResponse *response, uint8_t *buffer, size_t len) :
-      _response(response),
-      _buffer(buffer),
-      _length(len),
-      _pos(0)
-    {}
+    ChunkPrinter(PsychicResponse *response, uint8_t *buffer, size_t len);
+    ~ChunkPrinter();
+  
+    size_t write(uint8_t c) override;
+    size_t write(const uint8_t *buffer, size_t size) override;
 
-    virtual ~ChunkPrinter() {}
+    size_t copyFrom(Stream &stream);
 
-    size_t write(uint8_t c)
-    {
-      esp_err_t err;
-
-      _buffer[_pos] = c;
-      _pos++;
-
-      //if we're full, send a chunk
-      if (_pos == _length)
-      {
-        _pos = 0;
-
-        err = _response->sendChunk(_buffer, _length);
-        if (err != ESP_OK)
-          return 0;
-      }
-
-      return 1;
-    }
-
-    virtual void flush() override
-    {
-      if (_pos)
-      {
-        _response->sendChunk(_buffer, _pos);
-        _pos = 0;
-      }
-    }
+    void flush() override;
 };
 
 #endif

--- a/src/PsychicCore.h
+++ b/src/PsychicCore.h
@@ -16,6 +16,10 @@
   #define FILE_CHUNK_SIZE 8*1024
 #endif
 
+#ifndef STREAM_CHUNK_SIZE
+  #define STREAM_CHUNK_SIZE 1024
+#endif
+
 #ifndef MAX_UPLOAD_SIZE
   #define MAX_UPLOAD_SIZE (2048*1024) // 2MB
 #endif

--- a/src/PsychicFileResponse.cpp
+++ b/src/PsychicFileResponse.cpp
@@ -149,9 +149,6 @@ esp_err_t PsychicFileResponse::send()
       ESP_LOGI(PH_TAG, "File sending complete");
       this->finishChunking();
     }
-
-    /* Close file after sending complete */
-    _content.close();
   }
 
   return err;

--- a/src/PsychicFileResponse.cpp
+++ b/src/PsychicFileResponse.cpp
@@ -45,7 +45,6 @@ PsychicFileResponse::PsychicFileResponse(PsychicRequest *request, File content, 
 
   _content = content;
   _contentLength = _content.size();
-  setContentLength(_contentLength);
 
   if(contentType == "")
     _setContentType(path);

--- a/src/PsychicFileResponse.cpp
+++ b/src/PsychicFileResponse.cpp
@@ -6,13 +6,11 @@
 PsychicFileResponse::PsychicFileResponse(PsychicRequest *request, FS &fs, const String& path, const String& contentType, bool download)
  : PsychicResponse(request) {
   //_code = 200;
-  _path = path;
+  String _path(path);
 
   if(!download && !fs.exists(_path) && fs.exists(_path+".gz")){
     _path = _path+".gz";
     addHeader("Content-Encoding", "gzip");
-    _sendContentLength = true;
-    _chunked = false;
   }
 
   _content = fs.open(_path, "r");
@@ -39,12 +37,10 @@ PsychicFileResponse::PsychicFileResponse(PsychicRequest *request, FS &fs, const 
 
 PsychicFileResponse::PsychicFileResponse(PsychicRequest *request, File content, const String& path, const String& contentType, bool download)
  : PsychicResponse(request) {
-  _path = path;
+  String _path(path);
 
   if(!download && String(content.name()).endsWith(".gz") && !path.endsWith(".gz")){
     addHeader("Content-Encoding", "gzip");
-    _sendContentLength = true;
-    _chunked = false;
   }
 
   _content = content;

--- a/src/PsychicFileResponse.cpp
+++ b/src/PsychicFileResponse.cpp
@@ -21,8 +21,7 @@ PsychicFileResponse::PsychicFileResponse(PsychicRequest *request, FS &fs, const 
   if(contentType == "")
     _setContentType(path);
   else
-    _contentType = contentType;
-  setContentType(_contentType.c_str());
+    setContentType(contentType.c_str());
 
   int filenameStart = path.lastIndexOf('/') + 1;
   char buf[26+path.length()-filenameStart];
@@ -55,8 +54,7 @@ PsychicFileResponse::PsychicFileResponse(PsychicRequest *request, File content, 
   if(contentType == "")
     _setContentType(path);
   else
-    _contentType = contentType;
-  setContentType(_contentType.c_str());
+    setContentType(contentType.c_str());
 
   int filenameStart = path.lastIndexOf('/') + 1;
   char buf[26+path.length()-filenameStart];
@@ -77,6 +75,8 @@ PsychicFileResponse::~PsychicFileResponse()
 }
 
 void PsychicFileResponse::_setContentType(const String& path){
+  const char *_contentType;
+	
   if (path.endsWith(".html")) _contentType = "text/html";
   else if (path.endsWith(".htm")) _contentType = "text/html";
   else if (path.endsWith(".css")) _contentType = "text/css";
@@ -96,6 +96,8 @@ void PsychicFileResponse::_setContentType(const String& path){
   else if (path.endsWith(".zip")) _contentType = "application/zip";
   else if(path.endsWith(".gz")) _contentType = "application/x-gzip";
   else _contentType = "text/plain";
+  
+  setContentType(_contentType);
 }
 
 esp_err_t PsychicFileResponse::send()

--- a/src/PsychicFileResponse.h
+++ b/src/PsychicFileResponse.h
@@ -15,7 +15,6 @@ class PsychicFileResponse: public PsychicResponse
     String _path;
     bool _sendContentLength;
     bool _chunked;
-    String _contentType;
     void _setContentType(const String& path);
   public:
     PsychicFileResponse(PsychicRequest *request, FS &fs, const String& path, const String& contentType=String(), bool download=false);

--- a/src/PsychicFileResponse.h
+++ b/src/PsychicFileResponse.h
@@ -12,9 +12,6 @@ class PsychicFileResponse: public PsychicResponse
   using FS = fs::FS;
   private:
     File _content;
-    String _path;
-    bool _sendContentLength;
-    bool _chunked;
     void _setContentType(const String& path);
   public:
     PsychicFileResponse(PsychicRequest *request, FS &fs, const String& path, const String& contentType=String(), bool download=false);

--- a/src/PsychicHttp.h
+++ b/src/PsychicHttp.h
@@ -11,6 +11,7 @@
 #include "PsychicHandler.h"
 #include "PsychicStaticFileHandler.h"
 #include "PsychicFileResponse.h"
+#include "PsychicStreamResponse.h"
 #include "PsychicUploadHandler.h"
 #include "PsychicWebSocket.h"
 #include "PsychicEventSource.h"

--- a/src/PsychicStreamResponse.cpp
+++ b/src/PsychicStreamResponse.cpp
@@ -26,15 +26,18 @@ PsychicStreamResponse::~PsychicStreamResponse()
 
 esp_err_t PsychicStreamResponse::beginSend()
 {
+  if(_buffer)
+    return ESP_OK;
+
   //Buffer to hold ChunkPrinter and stream buffer. Using placement new will keep us at a single allocation.
   _buffer = (uint8_t*)malloc(STREAM_CHUNK_SIZE + sizeof(ChunkPrinter));
   
-    if(!_buffer)
-    {
-      /* Respond with 500 Internal Server Error */
-      httpd_resp_send_err(_request->request(), HTTPD_500_INTERNAL_SERVER_ERROR, "Unable to allocate memory.");
-      return ESP_FAIL;
-    }
+  if(!_buffer)
+  {
+    /* Respond with 500 Internal Server Error */
+    httpd_resp_send_err(_request->request(), HTTPD_500_INTERNAL_SERVER_ERROR, "Unable to allocate memory.");
+    return ESP_FAIL;
+  }
 
   _printer = new (_buffer) ChunkPrinter(this, _buffer + sizeof(ChunkPrinter), STREAM_CHUNK_SIZE);
 

--- a/src/PsychicStreamResponse.cpp
+++ b/src/PsychicStreamResponse.cpp
@@ -1,0 +1,86 @@
+#include "PsychicStreamResponse.h"
+#include "PsychicResponse.h"
+#include "PsychicRequest.h"
+
+PsychicStreamResponse::PsychicStreamResponse(PsychicRequest *request, const String& contentType)
+ : PsychicResponse(request), _buffer(NULL) {
+
+  setContentType(contentType.c_str());
+  addHeader("Content-Disposition", "inline");
+}
+ 
+PsychicStreamResponse::PsychicStreamResponse(PsychicRequest *request, const String& contentType, const String& name)
+  : PsychicResponse(request), _buffer(NULL) {
+
+  setContentType(contentType.c_str());
+
+  char buf[26+name.length()];
+  snprintf(buf, sizeof (buf), "attachment; filename=\"%s\"", name);
+  addHeader("Content-Disposition", buf);
+}
+ 
+PsychicStreamResponse::~PsychicStreamResponse()
+{
+  endSend();
+}
+
+esp_err_t PsychicStreamResponse::beginSend()
+{
+  //Buffer to hold ChunkPrinter and stream buffer. Using placement new will keep us at a single allocation.
+  _buffer = (uint8_t*)malloc(STREAM_CHUNK_SIZE + sizeof(ChunkPrinter));
+  
+    if(!_buffer)
+    {
+      /* Respond with 500 Internal Server Error */
+      httpd_resp_send_err(_request->request(), HTTPD_500_INTERNAL_SERVER_ERROR, "Unable to allocate memory.");
+      return ESP_FAIL;
+    }
+
+  _printer = new (_buffer) ChunkPrinter(this, _buffer + sizeof(ChunkPrinter), STREAM_CHUNK_SIZE);
+
+  sendHeaders();
+  return ESP_OK;
+}
+
+esp_err_t PsychicStreamResponse::endSend()
+{
+  esp_err_t err = ESP_OK;
+  
+  if(!_buffer)
+    err = ESP_FAIL;
+  else
+  {
+    //flush & send remaining data.
+    _printer->flush();
+    err = finishChunking();
+    
+    //Free memory
+    _printer->~ChunkPrinter();
+    free(_buffer);
+    _buffer = NULL;
+  }
+  return err;
+}
+
+void PsychicStreamResponse::flush()
+{
+  if(_buffer)
+    _printer->flush();
+}
+
+size_t PsychicStreamResponse::write(uint8_t data)
+{
+  return _buffer ? _printer->write(data) : 0;
+}
+
+size_t PsychicStreamResponse::copyFrom(Stream &stream)
+{
+  size_t sentCount = 0;
+  
+  if(_buffer)
+  {
+    while(stream.available())
+      sentCount += _printer->write(stream.read());
+  }
+  return sentCount;
+}

--- a/src/PsychicStreamResponse.h
+++ b/src/PsychicStreamResponse.h
@@ -1,0 +1,33 @@
+#ifndef PsychicStreamResponse_h
+#define PsychicStreamResponse_h
+
+#include "PsychicCore.h"
+#include "PsychicResponse.h"
+#include "ChunkPrinter.h"
+
+class PsychicRequest;
+
+class PsychicStreamResponse : public PsychicResponse, public Print
+{
+  private:
+    ChunkPrinter *_printer;
+    uint8_t *_buffer;
+  public:
+  
+    PsychicStreamResponse(PsychicRequest *request, const String& contentType);
+    PsychicStreamResponse(PsychicRequest *request, const String& contentType, const String& name); //Download
+  
+    ~PsychicStreamResponse();
+  
+    esp_err_t beginSend();
+    esp_err_t endSend();
+  
+    virtual void flush() override;
+
+    size_t write(uint8_t data);
+    size_t copyFrom(Stream &stream);
+  
+    using Print::write;
+};
+
+#endif // PsychicStreamResponse_h

--- a/src/PsychicStreamResponse.h
+++ b/src/PsychicStreamResponse.h
@@ -21,10 +21,12 @@ class PsychicStreamResponse : public PsychicResponse, public Print
   
     esp_err_t beginSend();
     esp_err_t endSend();
-  
-    virtual void flush() override;
 
-    size_t write(uint8_t data);
+    void flush() override;
+
+    size_t write(uint8_t data) override;
+    size_t write(const uint8_t *buffer, size_t size) override;
+  
     size_t copyFrom(Stream &stream);
   
     using Print::write;


### PR DESCRIPTION
First, this PR makes a few changes to `PsychicFileResponse`. There are a few instance variables that are not needed, and a few redundant calls. Resolves #44 

The main feature is a new class `PsychicStreamResponse` to allow using the `Print` interface to stream raw data.

I stayed away from copying what ESPAsyncWebServer does, especially as their implementation is limited in size (https://github.com/me-no-dev/ESPAsyncWebServer/issues/179#issuecomment-310047127).

This implementation makes use of the existing `ChunkPrinter` using a small buffer and supports unlimited size (no content length header is sent).

I was going to create two classes:

1. `PsychicStreamResponse` to keep with the typical fashion of passing a `Stream` to the constructor and using `response.send()` to initiate the copy.
2. `PsychicResponseStream` to use a `Print` interface (like ESPAsyncWebServer).

However, by adding the `copyFrom()` function to this candidate, it covers both classes in one.

Basic rundown of features:

- Write to the response like `Serial`.
- Can pass it to functions that accept a `Print` object.
- Can pass a `Stream` to the response to send the entire stream.

### Example 1 - Using the `Print` interface:

```C++
server.on("/testPrint", HTTP_GET, [](PsychicRequest *request) {
  PsychicStreamResponse response(request, "text/plain");

  response.beginSend();

  response.print("Free: ");
  response.print((double)ESP.getFreeHeap() / 1024.0, 2);
  response.print("Kb, Min: ");
  response.print((double)ESP.getMinFreeHeap() / 1024.0, 2);
  response.print("Kb, Max: ");
  response.print((double)ESP.getMaxAllocHeap() / 1024.0, 2);
  response.print("Kb, Size: ");
  response.println((double)ESP.getHeapSize() / 1024.0, 2); 

  return response.endSend();
});     
```

### Example 2 - Passing to other functions as a `Print` object:
*Sending a file can be done using `PsychicFileResponse`, this example is just to highlight the `Print` base class.*

```C++
void printFile(fs::FS &fs, const char * path, Print &out){
  File file = fs.open(path);
  if(!file){
      out.println("Failed to open file for reading");
      return;
  }

  while(file.available()){
      out.write(file.read());
  }
  file.close();
}

//...

server.on("/testFile1", HTTP_GET, [](PsychicRequest *request) {
  PsychicStreamResponse response(request, "text/html");

  response.beginSend();
  printFile(SD, "/www/index.html", response);
  return response.endSend();
}); 
```

### Example 3 - Copying from a `Stream`:
*Sending a file can be done using `PsychicFileResponse`, this example is just to highlight copying *any* `Stream`.*

```C++
server.on("/testFile2", HTTP_GET, [](PsychicRequest *request) {
  PsychicStreamResponse response(request, "text/html");

  response.beginSend();

  File file = SD.open("/www/index.html");
  response.copyFrom(file);
  file.close();

  return response.endSend();
});  
```

### Example 4 - Sending a download.
There are two constructors, the 2 param constructor in the above examples sends the response as `inline`. The 3 param constructor takes a name which is used as the download file name.

```C++
PsychicStreamResponse response(request, "text/plain", "thing.txt");
```
-----
I have a number of ideas we can discuss if warranted, this was the version I ended up with for the easiest use and safety.

One idea is to add a `send()` function. It can internally call the `beginSend()` & `endSend()`. An extra check will be needed to ensure no printer is setup after `endSend()` is called.
```C++
  return response.send([](Print &print){
    print.println("hello");
  });
```

Another overload could handle a `Stream`:
```C++
  return response.send(myStream);
```
However, there is no accommodation for closing a `FIle` if it is passed in, so another specific overload would be needed for `File` which can call the `Stream` overload, then close the file.

Although these ideas might make for some nice looking syntax, and can prevent using `beginSend()` & `endSend()`, they do not really add much value. But I'm open to adding these in (already tested) as they allow the user to choose.