### PR TITLE
Propose TemplatePrinter

### DIFF
--- a/src/TemplatePrinter.cpp
+++ b/src/TemplatePrinter.cpp
@@ -1,0 +1,78 @@
+
+#include "TemplatePrinter.h"
+
+void TemplatePrinter::resetParam(bool flush){
+  if(flush && _inParam){
+    _stream.write(_delimiter);
+    
+    if(_paramPos)
+      _stream.print(_paramBuffer);
+  }
+  
+  memset(_paramBuffer, 0, sizeof(_paramBuffer));
+  _paramPos = 0;
+  _inParam = false;
+}
+
+
+void TemplatePrinter::flush(){ 
+  resetParam(true);
+  _stream.flush();
+}
+
+size_t TemplatePrinter::write(uint8_t data){
+  
+  if(data == _delimiter){
+    
+    // End of parameter, send to callback
+    if(_inParam){
+      
+      // On false, return the parameter place holder as is: not a parameter
+      if(!_cb(_stream, _paramBuffer)){
+        resetParam(true);
+        _stream.write(data);
+      }else{
+        resetParam(false);
+      }
+      
+    // Start collecting parameter
+    }else{
+      _inParam = true;
+    }
+  }else{
+    
+    // Are we collecting
+    if(_inParam){
+      
+      // Is param still valid
+      if(isalnum(data) || data == '_'){
+        
+        // Total param len must be 63, 1 for null.
+        if(_paramPos < sizeof(_paramBuffer) - 1){
+          _paramBuffer[_paramPos++] = data;
+          
+        // Not a valid param
+        }else{
+          resetParam(true);
+        }
+      }else{
+        resetParam(true);
+        _stream.write(data);
+      }
+
+    // Just output
+    }else{
+      _stream.write(data);
+    }
+  }
+  return 1;
+}
+    
+size_t TemplatePrinter::copyFrom(Stream &stream){
+  size_t count = 0;
+  
+  while(stream.available())
+    count += this->write(stream.read());
+  
+  return count;
+}

--- a/src/TemplatePrinter.cpp
+++ b/src/TemplatePrinter.cpp
@@ -1,4 +1,15 @@
-
+  /************************************************************
+  
+	TemplatePrinter Class
+	
+	A basic templating engine for a stream of text.
+	This wraps the Arduino Print interface and writes to any
+	Print interface.
+	
+	Written by Christopher Andrews (https://github.com/Chris--A) 
+  
+  ************************************************************/
+  
 #include "TemplatePrinter.h"
 
 void TemplatePrinter::resetParam(bool flush){

--- a/src/TemplatePrinter.cpp
+++ b/src/TemplatePrinter.cpp
@@ -28,7 +28,8 @@ size_t TemplatePrinter::write(uint8_t data){
     if(_inParam){
       
       // On false, return the parameter place holder as is: not a parameter
-      if(!_cb(_stream, _paramBuffer)){
+	  // Bug fix: ignore parameters that are zero length.
+      if(!_paramPos || !_cb(_stream, _paramBuffer)){
         resetParam(true);
         _stream.write(data);
       }else{

--- a/src/TemplatePrinter.h
+++ b/src/TemplatePrinter.h
@@ -4,6 +4,18 @@
   #include "PsychicCore.h"
   #include <Print.h>
   
+  /************************************************************
+  
+	TemplatePrinter Class
+	
+	A basic templating engine for a stream of text.
+	This wraps the Arduino Print interface and writes to any
+	Print interface.
+	
+	Written by Christopher Andrews (https://github.com/Chris--A) 
+  
+  ************************************************************/
+  
   class TemplatePrinter;
 
   typedef std::function<bool(Print &output, const char *parameter)> TemplateCallback;

--- a/src/TemplatePrinter.h
+++ b/src/TemplatePrinter.h
@@ -1,0 +1,39 @@
+#ifndef TemplatePrinter_h
+  #define TemplatePrinter_h
+
+  #include "PsychicCore.h"
+  #include <Print.h>
+  
+  class TemplatePrinter;
+
+  typedef std::function<bool(Print &output, const char *parameter)> TemplateCallback;
+  typedef std::function<void(TemplatePrinter &printer)> TemplateSourceCallback;
+
+  class TemplatePrinter : public Print{
+    private:
+      bool _inParam;
+      char _paramBuffer[64];
+      uint8_t _paramPos;
+      Print &_stream;
+      TemplateCallback _cb;
+      char _delimiter;
+    
+      void resetParam(bool flush);
+      
+    public:
+      using Print::write;
+
+      static void start(Print &stream, TemplateCallback cb, TemplateSourceCallback entry){
+        TemplatePrinter printer(stream, cb);
+        entry(printer);
+      }
+
+      TemplatePrinter(Print &stream, TemplateCallback cb, const char delimeter = '%') : _stream(stream), _cb(cb), _delimiter(delimeter) { resetParam(false); }
+      ~TemplatePrinter(){ flush(); }
+
+      void flush() override;
+      size_t write(uint8_t data) override;
+      size_t copyFrom(Stream &stream);
+  };
+
+#endif


### PR DESCRIPTION
I have created a simple template processing tool. Primarily this has been built to work with `PsychicStreamResponse` proposed in #45. Incorporation directly into `PsychicStreamResponse` and other response types is possible. Implements some of #55. 

**This is not specific to PsychicHttp, and it works with any `Print` object. You could for example, template data out to `File`, `Serial`, etc...**.

The template engine is a `Print` interface and can be printed to directly, however,  if you are just templating a few short strings, I'd probably just use `response.printf()` instead. **Its benefit will be seen when templating large inputs such as files.**

One benefit may be **templating a **JSON** file avoiding the need to use ArduinoJson.**

Before closing the underlying `Print`/`Stream` that this writes to, it must be flushed as small amounts of data can be buffered. A convenience method to take care of this is shows in `example 3`.

The header file is not currently added to `PsychicHttp.h` and users will have to add it manually:

```C++
#include <TemplatePrinter.h>
```
 
## Template parameter definition:

- Must start and end with a preset delimiter, the default is `%`
- Can only contain `a-z`, `A-Z`, `0-9`, and `_`
- Maximum length of 63 characters (buffer is 64 including `null`).
- A parameter must not be zero length (not including delimiters).
- Spaces or any other character do not match as a parameter, and will be output as is.
- Valid examples
  - `%MY_PARAM%`
  - `%SOME1%`
- **Invalid** examples
  - `%MY PARAM%`
  - `%SOME1 %`
  - `%UNFINISHED`
  - `%%`

## Template processing
A function or lambda is used to receive the parameter replacement.

```C++
bool templateHandler(Print &output, const char *param){
  //...
}

[](Print &output, const char *param){
  //...
}
```

Parameters:
- `Print &output` - the underlying `Print`, print the results of templating to this.
- `const char *param` - a string containing the current parameter.

The handler must return a `bool`.
- `true`: the parameter was handled, continue as normal.
- `false`: the input detected as a parameter is not, print literal.

See output in **example 1** regarding the effects of returning `true` or `false`.

## Template input handler
This is not needed unless using the static convenience function `TemplatePrinter::start()`. See **example 3**.

```C++
bool inputHandler(TemplatePrinter &printer){
  //...
}

[](TemplatePrinter &printer){
  //...
}
```

Parameters:
- `TemplatePrinter &printer` - The template engine, print your template text to this for processing.


## Example 1 - Simple use with `PsychicStreamResponse`:
This example highlights its most basic usage.

```C++

//  Function to handle parameter requests.

bool templateHandler(Print &output, const char *param){

  if(strcmp(param, "FREE_HEAP") == 0){
    output.print((double)ESP.getFreeHeap() / 1024.0, 2);

  }else if(strcmp(param, "MIN_FREE_HEAP") == 0){
    output.print((double)ESP.getMinFreeHeap() / 1024.0, 2);

  }else if(strcmp(param, "MAX_ALLOC_HEAP") == 0){
    output.print((double)ESP.getMaxAllocHeap() / 1024.0, 2);
    
  }else if(strcmp(param, "HEAP_SIZE") == 0){
    output.print((double)ESP.getHeapSize() / 1024.0, 2);
  }else{
    return false;
  }
  output.print("Kb");
  return true;
}

//  Example serving a request
server.on("/template", [](PsychicRequest *request) {
  PsychicStreamResponse response(request, "text/plain");

  response.beginSend();
  
  TemplatePrinter printer(response, templateHandler);

  printer.println("My ESP has %FREE_HEAP% left. Its lifetime minimum heap is %MIN_FREE_HEAP%.");
  printer.println("The maximum allocation size is %MAX_ALLOC_HEAP%, and its total size is %HEAP_SIZE%.");
  printer.println("This is an unhandled parameter: %UNHANDLED_PARAM% and this is an invalid param %INVALID PARAM%.");
  printer.println("This line finished with %UNFIN");
  printer.flush();

  return response.endSend();
});   
```

The output for example looks like:
```
My ESP has 170.92Kb left. Its lifetime minimum heap is 169.83Kb.
The maximum allocation size is 107.99Kb, and its total size is 284.19Kb.
This is an unhandled parameter: %UNHANDLED_PARAM% and this is an invalid param %INVALID PARAM%.
This line finished with %UNFIN
```

## Example 2 - Templating a file

```C++
server.on("/home", [](PsychicRequest *request) {
  PsychicStreamResponse response(request, "text/html");
  File file = SD.open("/www/index.html");

  response.beginSend();

  TemplatePrinter printer(response, templateHandler);

  printer.copyFrom(file);
  printer.flush();
  file.close();

  return response.endSend();
}); 
```

## Example 3 - Using the `TemplatePrinter::start` method.
This static method allows an RAII approach, allowing you to template a stream, etc... without needing a `flush()`. The function call is laid out as:

```C++
TemplatePrinter::start(host_stream, template_handler, input_handler);
```

\*these examples use the `templateHandler` function defined in example 1.

### Serve a file like example 2
```C++
server.on("/home", [](PsychicRequest *request) {
  PsychicStreamResponse response(request, "text/html");
  File file = SD.open("/www/index.html");

  response.beginSend();
  TemplatePrinter::start(response, templateHandler, [&file](TemplatePrinter &printer){
    printer.copyFrom(file);
  });
  file.close();

  return response.endSend();
});
```

### Template a string like example 1
```C++
server.on("/template2", [](PsychicRequest *request) {

  PsychicStreamResponse response(request, "text/plain");

  response.beginSend();

  TemplatePrinter::start(response, templateHandler, [](TemplatePrinter &printer){
    printer.println("My ESP has %FREE_HEAP% left. Its lifetime minimum heap is %MIN_FREE_HEAP%.");
    printer.println("The maximum allocation size is %MAX_ALLOC_HEAP%, and its total size is %HEAP_SIZE%.");
    printer.println("This is an unhandled parameter: %UNHANDLED_PARAM% and this is an invalid param %INVALID PARAM%.");
  });

  return response.endSend();
});
```





