### PR TITLE
Update PsychicWebSocket.cpp to allow binary payloads

### DIFF
--- a/src/PsychicWebSocket.cpp
+++ b/src/PsychicWebSocket.cpp
@@ -192,7 +192,7 @@ esp_err_t PsychicWebSocketHandler::handleRequest(PsychicRequest *request)
   }
 
   // Text messages are our payload.
-  if (ws_pkt.type == HTTPD_WS_TYPE_TEXT)
+  if (ws_pkt.type == HTTPD_WS_TYPE_TEXT || ws_pkt.type == HTTPD_WS_TYPE_BINARY)
   {
     if (this->_onFrame != NULL)
       ret = this->_onFrame(&wsRequest, &ws_pkt);


### PR DESCRIPTION
This would allow protobuf / binary encodings to be exchanged on top of Websockets