### PR TITLE
Modify code for compilation in ESP-IDF environment

### DIFF
--- a/src/PsychicHandler.h
+++ b/src/PsychicHandler.h
@@ -28,7 +28,7 @@ class PsychicHandler {
 
   public:
     PsychicHandler();
-    ~PsychicHandler();
+    virtual ~PsychicHandler();
 
     PsychicHandler* setFilter(PsychicRequestFilterFunction fn);
     bool filter(PsychicRequest *request);

--- a/src/PsychicHttpServer.h
+++ b/src/PsychicHttpServer.h
@@ -25,7 +25,7 @@ class PsychicHttpServer
 
   public:
     PsychicHttpServer();
-    ~PsychicHttpServer();
+    virtual ~PsychicHttpServer();
 
     //esp-idf specific stuff
     httpd_handle_t server;

--- a/src/PsychicRequest.cpp
+++ b/src/PsychicRequest.cpp
@@ -469,7 +469,7 @@ const String PsychicRequest::_getRandomHexString()
   char buffer[33];  // buffer to hold 32 Hex Digit + /0
   int i;
   for(i = 0; i < 4; i++) {
-    sprintf (buffer + (i*8), "%08lx", esp_random());
+    sprintf (buffer + (i*8), "%08lx", (unsigned long int)esp_random());
   }
   return String(buffer);
 }

--- a/src/PsychicStreamResponse.cpp
+++ b/src/PsychicStreamResponse.cpp
@@ -16,7 +16,7 @@ PsychicStreamResponse::PsychicStreamResponse(PsychicRequest *request, const Stri
   setContentType(contentType.c_str());
 
   char buf[26+name.length()];
-  snprintf(buf, sizeof (buf), "attachment; filename=\"%s\"", name);
+  snprintf(buf, sizeof (buf), "attachment; filename=\"%s\"", name.c_str());
   addHeader("Content-Disposition", buf);
 }
 

--- a/src/PsychicUploadHandler.cpp
+++ b/src/PsychicUploadHandler.cpp
@@ -36,7 +36,7 @@ esp_err_t PsychicUploadHandler::handleRequest(PsychicRequest *request)
 
     /* Respond with 400 Bad Request */
     char error[50];
-    sprintf(error, "File size must be less than %u bytes!", request->server()->maxUploadSize);
+    sprintf(error, "File size must be less than %lu bytes!", request->server()->maxUploadSize);
     httpd_resp_send_err(request->request(), HTTPD_400_BAD_REQUEST, error);
 
     /* Return failure to close underlying connection else the incoming file content will keep the socket busy */

--- a/src/PsychicWebHandler.cpp
+++ b/src/PsychicWebHandler.cpp
@@ -26,7 +26,7 @@ esp_err_t PsychicWebHandler::handleRequest(PsychicRequest *request)
 
     /* Respond with 400 Bad Request */
     char error[60];
-    sprintf(error, "Request body must be less than %u bytes!", request->server()->maxRequestBodySize);
+    sprintf(error, "Request body must be less than %lu bytes!", request->server()->maxRequestBodySize);
     httpd_resp_send_err(request->request(), HTTPD_400_BAD_REQUEST, error);
 
     /* Return failure to close underlying connection else the incoming file content will keep the socket busy */

--- a/src/async_worker.cpp
+++ b/src/async_worker.cpp
@@ -166,7 +166,7 @@ esp_err_t httpd_req_async_handler_begin(httpd_req_t *r, httpd_req_t **out)
     if (async == NULL) {
         return ESP_ERR_NO_MEM;
     }
-    memcpy(async, r, sizeof(httpd_req_t));
+    memcpy((void *)async, (void *)r, sizeof(httpd_req_t));
 
     // alloc async aux
     async->aux = (httpd_req_aux *)malloc(sizeof(struct httpd_req_aux));


### PR DESCRIPTION
This PR addresses the compilation errors that occurred when using the Arduino and ESP-IDF frameworks in the PlatformIO environment. Now, users can utilize these libraries in the ESP-IDF environment, enabling them to customize detailed settings by modifying the sdkconfig.

Related Issue: #68 