### PR TITLE
add WebSocket subprotocol support

### DIFF
--- a/src/PsychicHandler.cpp
+++ b/src/PsychicHandler.cpp
@@ -7,7 +7,8 @@ PsychicHandler::PsychicHandler() :
   _password(""),
   _method(DIGEST_AUTH),
   _realm(""),
-  _authFailMsg("")
+  _authFailMsg(""),
+  _subprotocol("")
   {}
 
 PsychicHandler::~PsychicHandler() {
@@ -24,6 +25,13 @@ PsychicHandler* PsychicHandler::setFilter(PsychicRequestFilterFunction fn) {
 
 bool PsychicHandler::filter(PsychicRequest *request){
   return _filter == NULL || _filter(request);
+}
+
+void PsychicHandler::setSubprotocol(const String& subprotocol) {
+    this->_subprotocol = subprotocol;
+}
+const char* PsychicHandler::getSubprotocol() const {
+    return _subprotocol.c_str();
 }
 
 PsychicHandler* PsychicHandler::setAuthentication(const char *username, const char *password, HTTPAuthMethod method, const char *realm, const char *authFailMsg) {

--- a/src/PsychicHandler.h
+++ b/src/PsychicHandler.h
@@ -24,6 +24,8 @@ class PsychicHandler {
     String _realm;
     String _authFailMsg;
 
+    String _subprotocol;
+
     std::list<PsychicClient*> _clients;
 
   public:
@@ -38,6 +40,9 @@ class PsychicHandler {
     esp_err_t authenticate(PsychicRequest *request);
 
     virtual bool isWebSocket() { return false; };
+
+    void setSubprotocol(const String& subprotocol);
+    const char* getSubprotocol() const;
 
     PsychicClient * checkForNewClient(PsychicClient *client);
     void checkForClosedClient(PsychicClient *client);

--- a/src/PsychicHttpServer.cpp
+++ b/src/PsychicHttpServer.cpp
@@ -141,7 +141,8 @@ PsychicEndpoint* PsychicHttpServer::on(const char* uri, http_method method, Psyc
     .method   = method,
     .handler  = PsychicEndpoint::requestCallback,
     .user_ctx = endpoint,
-    .is_websocket = handler->isWebSocket()
+    .is_websocket = handler->isWebSocket(),
+    .supported_subprotocol = handler->getSubprotocol()
   };
   
   // Register endpoint with ESP-IDF server


### PR DESCRIPTION
added _subprotocol member variable to PsychicHandler class

set the websocket subprotocol with setSubprotocol -- i.e.  handler.setSubprotocol("can.binary+json.v1") 
(to talk to python-can-remote)

in PsychicHttpServer.cpp added field supported_subprotocol to httpd_uri_t 
this field is in esp_http_server.h - but wasn't implemented in PsychicHttp
