### PR TITLE
Undo free header after send

### DIFF
--- a/src/PsychicResponse.cpp
+++ b/src/PsychicResponse.cpp
@@ -123,17 +123,28 @@ void PsychicResponse::sendHeaders()
 {
   //get our global headers out of the way first
   for (HTTPHeader header : DefaultHeaders::Instance().getHeaders())
+  {
     httpd_resp_set_hdr(_request->request(), header.field, header.value);
+    //Log global header
+    ESP_LOGI(PH_TAG, "HEADER_G[%s]: %s\n", header.field, header.value);
+  }
 
   //now do our individual headers
   for (HTTPHeader header : _headers)
+  {
     httpd_resp_set_hdr(this->_request->request(), header.field, header.value);
-
+    //Log individual header
+    ESP_LOGI(PH_TAG, "HEADER_I[%s]: %s\n", header.field, header.value);
+  }
   // clean up our header variables after send
   for (HTTPHeader header : _headers)
   {
-    free(header.field);
-    free(header.value);
+    //Work around: Keep "Location" and "Content-Disposition" or captivate portal not show in iPhone Safari, what wrong?
+    if (strcmp(header.field, "Location") && strcmp(header.field, "Content-Disposition"))
+    {
+      free(header.field);
+      free(header.value);
+    }
   }
   _headers.clear();
 }

--- a/src/PsychicResponse.cpp
+++ b/src/PsychicResponse.cpp
@@ -136,17 +136,7 @@ void PsychicResponse::sendHeaders()
     //Log individual header
     ESP_LOGI(PH_TAG, "HEADER_I[%s]: %s\n", header.field, header.value);
   }
-  // clean up our header variables after send
-  for (HTTPHeader header : _headers)
-  {
-    //Work around: Keep "Location" and "Content-Disposition" or captivate portal not show in iPhone Safari, what wrong?
-    if (strcmp(header.field, "Location") && strcmp(header.field, "Content-Disposition"))
-    {
-      free(header.field);
-      free(header.value);
-    }
-  }
-  _headers.clear();
+  // clean up header make cookie and other feature not work
 }
 
 esp_err_t PsychicResponse::sendChunk(uint8_t *chunk, size_t chunksize)


### PR DESCRIPTION
The problem cause lost custom header and cookie not set with the bug fix: https://github.com/hoeken/PsychicHttp/blob/62f443916199030eb708c7de79fd3552eb5f174e/src/PsychicResponse.cpp#L133

I have problem with the login base cookie and captivate portal not open in iPhone with the fix for memory in in PsychicResponse::sendHeaders(), delete code free header it working normal, So better we investigate further by undo it . I log the header when app running and see you are not using https://github.com/hoeken/PsychicHttp/blob/62f443916199030eb708c7de79fd3552eb5f174e/src/PsychicCore.h#L70.

We can also persistent headers/cookies bu not using malloc, use native Arduino String or c++ std::string is other option. 