### PR TITLE
Defer Endpoint registering after server start

### DIFF
--- a/src/PsychicEndpoint.h
+++ b/src/PsychicEndpoint.h
@@ -18,6 +18,7 @@ class PsychicEndpoint
     String _uri;
     http_method _method;
     PsychicHandler *_handler;
+    bool _registered = false;
 
   public:
     PsychicEndpoint();
@@ -30,6 +31,9 @@ class PsychicEndpoint
     PsychicEndpoint* setAuthentication(const char *username, const char *password, HTTPAuthMethod method = BASIC_AUTH, const char *realm = "", const char *authFailMsg = "");
 
     String uri();
+
+    esp_err_t install();
+    esp_err_t uninstall();
 
     static esp_err_t requestCallback(httpd_req_t *req);
 };

--- a/src/PsychicHttpServer.h
+++ b/src/PsychicHttpServer.h
@@ -22,6 +22,7 @@ class PsychicHttpServer
 
     esp_err_t _start();
     virtual esp_err_t _startServer();
+    bool _started = false;
 
   public:
     PsychicHttpServer();
@@ -39,10 +40,11 @@ class PsychicHttpServer
 
     esp_err_t listen(uint16_t port);
 
-    virtual void stop();
+    virtual esp_err_t stop();
 
     PsychicHandler& addHandler(PsychicHandler* handler);
     void removeHandler(PsychicHandler* handler);
+    esp_err_t removeEndpoint(PsychicEndpoint* endpoint);
 
     void addClient(PsychicClient *client);
     void removeClient(PsychicClient *client);

--- a/src/PsychicHttpsServer.cpp
+++ b/src/PsychicHttpsServer.cpp
@@ -49,12 +49,24 @@ esp_err_t PsychicHttpsServer::_startServer()
     return httpd_start(&this->server, &this->config);
 }
 
-void PsychicHttpsServer::stop()
+esp_err_t PsychicHttpsServer::stop()
 {
+  esp_err_t ret = ESP_OK
+
   if (this->_use_ssl)
-    httpd_ssl_stop(this->server);
+    ret = httpd_ssl_stop(this->server);
   else
-    httpd_stop(this->server);
+    ret = httpd_stop(this->server);
+
+  if(ret != ESP_OK)
+  {
+    ESP_LOGE(PH_TAG, "Server stop failed (%s)", esp_err_to_name(ESP_FAIL));
+    return ret;
+  }
+
+  _started = false;
+  ESP_LOGI(PH_TAG, "Server stopped");
+  return ret;
 }
 
 #endif // CONFIG_ESP_HTTPS_SERVER_ENABLE

--- a/src/PsychicHttpsServer.h
+++ b/src/PsychicHttpsServer.h
@@ -27,7 +27,7 @@ class PsychicHttpsServer : public PsychicHttpServer
     esp_err_t listen(uint16_t port, const char *cert, const char *private_key);
 
     virtual esp_err_t _startServer() override final;
-    virtual void stop() override final;
+    virtual esp_err_t stop() override final;
 };
 
 #endif // PsychicHttpsServer_h


### PR DESCRIPTION
This change allows to register endpoints before server startup and they will be registered once server is started.