### PR TITLE
Support content-type followed by a charset (#122)

### DIFF
--- a/examples/old/simple_http_server/test/tests.rest
+++ b/examples/old/simple_http_server/test/tests.rest
@@ -18,7 +18,7 @@ GET {{baseUrl}}/get?message=Hello+World HTTP/1.1
 ###
 
 POST {{baseUrl}}/post HTTP/1.1
-Content-Type: application/x-www-form-urlencoded
+Content-Type: application/x-www-form-urlencoded;charset=UTF-8
 
 message=Hello+World
 

--- a/examples/old/websocket_chat/test/tests.rest
+++ b/examples/old/websocket_chat/test/tests.rest
@@ -18,7 +18,7 @@ GET {{baseUrl}}/get?message=Hello+World HTTP/1.1
 ###
 
 POST {{baseUrl}}/post HTTP/1.1
-Content-Type: application/x-www-form-urlencoded
+Content-Type: application/x-www-form-urlencoded;charset=UTF-8
 
 message=Hello+World
 

--- a/src/PsychicRequest.cpp
+++ b/src/PsychicRequest.cpp
@@ -284,7 +284,7 @@ void PsychicRequest::loadParams()
   }
 
   //did we get form data as body?
-  if (this->method() == HTTP_POST && this->contentType() == "application/x-www-form-urlencoded")
+  if (this->method() == HTTP_POST && this->contentType().startsWith("application/x-www-form-urlencoded"))
   {
     _addParams(_body);
   }


### PR DESCRIPTION
- Fix #122

Note: I did not test. I just saw that only the base content-type is checked, which seems weird because it is often followed by a charset. ESPAsyncWS is also doing a `startsWith` fyi.

I guess the IDF API is no different because it does not state that it parses separately the ct and charset, neither that it has a method specifically to get the charset of a ct.