### PR TITLE
Prevent Psychic from committing a suicide: the object already cleanup  its resources when going out of scope or deleted externally by the user

### DIFF
--- a/src/PsychicHttpServer.cpp
+++ b/src/PsychicHttpServer.cpp
@@ -23,7 +23,6 @@ PsychicHttpServer::PsychicHttpServer() :
   config.close_fn = PsychicHttpServer::closeCallback;
   config.uri_match_fn = httpd_uri_match_wildcard;
   config.global_user_ctx = this;
-  config.global_user_ctx_free_fn = destroy;
   config.max_uri_handlers = 20;
 
   #ifdef ENABLE_ASYNC
@@ -52,12 +51,6 @@ PsychicHttpServer::~PsychicHttpServer()
   _handlers.clear();
 
   delete defaultEndpoint;
-}
-
-void PsychicHttpServer::destroy(void *ctx)
-{
-  PsychicHttpServer *temp = (PsychicHttpServer *)ctx;
-  delete temp;
 }
 
 esp_err_t PsychicHttpServer::listen(uint16_t port)

--- a/src/PsychicHttpServer.h
+++ b/src/PsychicHttpServer.h
@@ -37,8 +37,6 @@ class PsychicHttpServer
 
     PsychicEndpoint *defaultEndpoint;
 
-    static void destroy(void *ctx);
-
     esp_err_t listen(uint16_t port);
 
     virtual void stop();

--- a/src/PsychicHttpsServer.cpp
+++ b/src/PsychicHttpsServer.cpp
@@ -10,7 +10,6 @@ PsychicHttpsServer::PsychicHttpsServer() : PsychicHttpServer()
   ssl_config.httpd.close_fn = PsychicHttpServer::closeCallback;
   ssl_config.httpd.uri_match_fn = httpd_uri_match_wildcard;
   ssl_config.httpd.global_user_ctx = this;
-  ssl_config.httpd.global_user_ctx_free_fn = destroy;
   ssl_config.httpd.max_uri_handlers = 20;
 
   // each SSL connection takes about 45kb of heap


### PR DESCRIPTION
```c++
  #7  0x400d49fd in PsychicHttpServer::~PsychicHttpServer() at /Users/mat/Data/Workspace/forks/PsychicHttp/src/PsychicHttpServer.cpp:56
  #8  0x4018014b in PsychicHttpServer::destroy(void*) at /Users/mat/Data/Workspace/forks/PsychicHttp/src/PsychicHttpServer.cpp:61 (discriminator 1)
  #9  0x4010a1a2 in httpd_stop at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/esp_http_server/src/httpd_main.c:558
  #10 0x400d4190 in PsychicHttpServer::stop() at /Users/mat/Data/Workspace/forks/PsychicHttp/src/PsychicHttpServer.cpp:113
```