### PR TITLE
Fix suicide bug when stopping

### DIFF
--- a/src/PsychicHttpServer.cpp
+++ b/src/PsychicHttpServer.cpp
@@ -56,8 +56,7 @@ PsychicHttpServer::~PsychicHttpServer()
 
 void PsychicHttpServer::destroy(void *ctx)
 {
-  PsychicHttpServer *temp = (PsychicHttpServer *)ctx;
-  delete temp;
+  // do not release any resource for PsychicHttpServer in order to be able to restart it after stopping
 }
 
 esp_err_t PsychicHttpServer::listen(uint16_t port)

--- a/src/PsychicHttpServer.cpp
+++ b/src/PsychicHttpServer.cpp
@@ -23,6 +23,7 @@ PsychicHttpServer::PsychicHttpServer() :
   config.close_fn = PsychicHttpServer::closeCallback;
   config.uri_match_fn = httpd_uri_match_wildcard;
   config.global_user_ctx = this;
+  config.global_user_ctx_free_fn = destroy;
   config.max_uri_handlers = 20;
 
   #ifdef ENABLE_ASYNC
@@ -51,6 +52,12 @@ PsychicHttpServer::~PsychicHttpServer()
   _handlers.clear();
 
   delete defaultEndpoint;
+}
+
+void PsychicHttpServer::destroy(void *ctx)
+{
+  PsychicHttpServer *temp = (PsychicHttpServer *)ctx;
+  delete temp;
 }
 
 esp_err_t PsychicHttpServer::listen(uint16_t port)

--- a/src/PsychicHttpServer.h
+++ b/src/PsychicHttpServer.h
@@ -37,6 +37,8 @@ class PsychicHttpServer
 
     PsychicEndpoint *defaultEndpoint;
 
+    static void destroy(void *ctx);
+
     esp_err_t listen(uint16_t port);
 
     virtual void stop();

--- a/src/PsychicHttpsServer.cpp
+++ b/src/PsychicHttpsServer.cpp
@@ -10,6 +10,7 @@ PsychicHttpsServer::PsychicHttpsServer() : PsychicHttpServer()
   ssl_config.httpd.close_fn = PsychicHttpServer::closeCallback;
   ssl_config.httpd.uri_match_fn = httpd_uri_match_wildcard;
   ssl_config.httpd.global_user_ctx = this;
+  ssl_config.httpd.global_user_ctx_free_fn = destroy;
   ssl_config.httpd.max_uri_handlers = 20;
 
   // each SSL connection takes about 45kb of heap


### PR DESCRIPTION
Stopping the server was making it commit suicide. It turns out that removing the handler like I did had a side effect because IDF then tries to free the pointer to the server itself:

```
assert failed: heap_caps_free heap_caps_base.c:63 (heap != NULL && "free() target pointer is outside heap areas")


Backtrace: 0x400833c5:0x3ffb1fa0 0x4008c3f9:0x3ffb1fc0 0x400919b6:0x3ffb1fe0 0x400836dd:0x3ffb2110 0x400919f5:0x3ffb2130 0x4010978c:0x3ffb2150 0x400d4114:0x3ffb2180 0x400d937e:0x3ffb21c0 0x400da125:0x3ffb2210 0x400da34c:0x3ffb2230 0x400d3192:0x3ffb2250 0x400dda74:0x3ffb2270 0x4008ea92:0x3ffb2290
  #0  0x400833c5 in panic_abort at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/esp_system/panic.c:466
  #1  0x4008c3f9 in esp_system_abort at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/esp_system/port/esp_system_chip.c:84
  #2  0x400919b6 in __assert_func at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/newlib/assert.c:81
  #3  0x400836dd in heap_caps_free at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/heap/heap_caps_base.c:63
  #4  0x400919f5 in free at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/newlib/heap.c:39
  #5  0x4010978c in httpd_stop at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/esp_http_server/src/httpd_main.c:560
  #6  0x400d4114 in PsychicHttpServer::stop() at /Users/mat/Data/Workspace/forks/PsychicHttp/src/PsychicHttpServer.cpp:107
```

https://github.com/espressif/esp-idf/blob/v5.1.4/components/esp_http_server/src/httpd_main.c#L556-L563

So the solution is to keep the handler to have a control over what gets freed (and then free nothing).