### PR TITLE
2. Refactor the listen method which is doing to many things

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ If you have existing code using ESPAsyncWebserver, you will feel right at home w
 
 ## setup() Stuff
 
-* no more server.begin(), call server.listen(80), before you add your handlers
+* add your handlers and call server.begin()
 * server has a configurable limit on .on() endpoints. change it with ```server.config.max_uri_handlers = 20;``` as needed.
 * check your callback function definitions:
    * AsyncWebServerRequest -> PsychicRequest
@@ -163,9 +163,6 @@ void setup()
    server.config.max_uri_handlers = 20; 
 
    //connect to wifi
-
-   //start the server listening on port 80 (standard HTTP port)
-   server.listen(80);
 
    //call server methods to attach endpoints and handlers
    server.on(...);
@@ -524,7 +521,7 @@ PsychicHttp supports HTTPS / SSL out of the box, however there are some limitati
 #include <PsychicHttp.h>
 #include <PsychicHttpsServer.h>
 PsychicHttpsServer server;
-server.listen(443, server_cert, server_key);
+server.setCertificate(server_cert, server_key);
 ```
 
 ```server_cert``` and ```server_key``` are both ```const char *``` parameters which contain the server certificate and private key, respectively.
@@ -552,7 +549,6 @@ Last, but not least, you can create a separate HTTP server on port 80 that redir
 //this creates a 2nd server listening on port 80 and redirects all requests HTTPS
 PsychicHttpServer *redirectServer = new PsychicHttpServer();
 redirectServer->config.ctrl_port = 20420; // just a random port different from the default one
-redirectServer->listen(80);
 redirectServer->onNotFound([](PsychicRequest *request) {
    String url = "https://" + request->host() + request->url();
    return request->redirect(url.c_str());

--- a/benchmark/psychichttp/src/main.cpp
+++ b/benchmark/psychichttp/src/main.cpp
@@ -176,9 +176,6 @@ void setup()
       return;
     }
 
-    //start our server
-    server.listen(80);
-
     //our index
     server.on("/", HTTP_GET, [](PsychicRequest *request)
     {

--- a/benchmark/psychichttps/src/main.cpp
+++ b/benchmark/psychichttps/src/main.cpp
@@ -187,7 +187,7 @@ void setup()
     fp2.close();
 
     //start our server
-    server.listen(443, server_cert.c_str(), server_key.c_str());
+    server.setCertificate(server_cert.c_str(), server_key.c_str());
 
     //our index
     server.on("/", HTTP_GET, [](PsychicRequest *request)

--- a/examples/arduino/arduino.ino
+++ b/examples/arduino/arduino.ino
@@ -206,21 +206,16 @@ void setup()
       //do we want secure or not?
       if (app_enable_ssl)
       {
-        server.listen(443, server_cert.c_str(), server_key.c_str());
+        server.setCertificate(server_cert.c_str(), server_key.c_str());
         
         //this creates a 2nd server listening on port 80 and redirects all requests HTTPS
         PsychicHttpServer *redirectServer = new PsychicHttpServer();
         redirectServer->config.ctrl_port = 20424; // just a random port different from the default one
-        redirectServer->listen(80);
         redirectServer->onNotFound([](PsychicRequest *request) {
           String url = "https://" + request->host() + request->url();
           return request->redirect(url.c_str());
         });
       }
-      else
-        server.listen(80);
-    #else
-      server.listen(80);
     #endif
 
     //serve static files from LittleFS/www on / only to clients on same wifi network

--- a/examples/arduino/arduino_captive_portal/arduino_captive_portal.ino
+++ b/examples/arduino/arduino_captive_portal/arduino_captive_portal.ino
@@ -128,7 +128,6 @@ void setup() {
 
     //setup server config stuff here
     server.config.max_uri_handlers = 20; //maximum number of uri handlers (.on() calls)
-    server.listen(80);
         
     DefaultHeaders::Instance().addHeader("Server", "PsychicHttp");
 

--- a/examples/arduino/arduino_ota/arduino_ota.ino
+++ b/examples/arduino/arduino_ota/arduino_ota.ino
@@ -100,7 +100,6 @@ void setup()
 
     //setup server config stuff here
     server.config.max_uri_handlers = 20;     //maximum number of uri handlers (.on() calls) 
-    server.listen(80);
 
     DefaultHeaders::Instance().addHeader("Server", "PsychicHttp");
 

--- a/examples/esp-idf/main/main.cpp
+++ b/examples/esp-idf/main/main.cpp
@@ -208,21 +208,16 @@ void setup()
       //do we want secure or not?
       if (app_enable_ssl)
       {
-        server.listen(443, server_cert.c_str(), server_key.c_str());
+        server.setCertificate(server_cert.c_str(), server_key.c_str());
         
         //this creates a 2nd server listening on port 80 and redirects all requests HTTPS
         PsychicHttpServer *redirectServer = new PsychicHttpServer();
         redirectServer->config.ctrl_port = 20424; // just a random port different from the default one
-        redirectServer->listen(80);
         redirectServer->onNotFound([](PsychicRequest *request) {
           String url = "https://" + request->host() + request->url();
           return request->redirect(url.c_str());
         });
       }
-      else
-        server.listen(80);
-    #else
-      server.listen(80);
     #endif
 
     //serve static files from LittleFS/www on / only to clients on same wifi network

--- a/examples/platformio/src/main.cpp
+++ b/examples/platformio/src/main.cpp
@@ -226,21 +226,16 @@ void setup()
       //do we want secure or not?
       if (app_enable_ssl)
       {
-        server.listen(443, server_cert.c_str(), server_key.c_str());
+        server.setCertificate(server_cert.c_str(), server_key.c_str());
         
         //this creates a 2nd server listening on port 80 and redirects all requests HTTPS
         PsychicHttpServer *redirectServer = new PsychicHttpServer();
         redirectServer->config.ctrl_port = 20424; // just a random port different from the default one
-        redirectServer->listen(80);
         redirectServer->onNotFound([](PsychicRequest *request) {
           String url = "https://" + request->host() + request->url();
           return request->redirect(url.c_str());
         });
       }
-      else
-        server.listen(80);
-    #else
-      server.listen(80);
     #endif
 
     DefaultHeaders::Instance().addHeader("Server", "PsychicHttp");

--- a/examples/websockets/src/main.cpp
+++ b/examples/websockets/src/main.cpp
@@ -135,8 +135,6 @@ void setup()
       return;
     }
 
-    server.listen(80);
-
     //this is where our /index.html file lives
     // curl -i http://psychic.local/
     PsychicStaticFileHandler* handler = server.serveStatic("/", LittleFS, "/www/");

--- a/src/PsychicHttpServer.cpp
+++ b/src/PsychicHttpServer.cpp
@@ -7,7 +7,7 @@
 #include "PsychicJson.h"
 #include "WiFi.h"
 
-PsychicHttpServer::PsychicHttpServer() :
+PsychicHttpServer::PsychicHttpServer(uint16_t port) :
   _onOpen(NULL),
   _onClose(NULL)
 {
@@ -39,6 +39,8 @@ PsychicHttpServer::PsychicHttpServer() :
     config.max_open_sockets = ASYNC_WORKER_COUNT + 1;
     config.lru_purge_enable = true;
   #endif
+
+  setPort(port);
 }
 
 PsychicHttpServer::~PsychicHttpServer()
@@ -63,9 +65,8 @@ void PsychicHttpServer::destroy(void *ctx)
   // do not release any resource for PsychicHttpServer in order to be able to restart it after stopping
 }
 
-void PsychicHttpServer::listen(uint16_t port)
+void PsychicHttpServer::setPort(uint16_t port)
 {
-  this->_use_ssl = false;
   this->config.server_port = port;
 }
 

--- a/src/PsychicHttpServer.h
+++ b/src/PsychicHttpServer.h
@@ -14,8 +14,6 @@ class PsychicStaticFileHandler;
 class PsychicHttpServer
 {
   protected:
-    bool _use_ssl = false;
-
     std::list<httpd_uri_t> _esp_idf_endpoints;
     std::list<PsychicEndpoint*> _endpoints;
     std::list<PsychicHandler*> _handlers;
@@ -30,7 +28,7 @@ class PsychicHttpServer
     bool _running = false;
 
   public:
-    PsychicHttpServer();
+    PsychicHttpServer(uint16_t port = 80);
     virtual ~PsychicHttpServer();
 
     //what methods to support
@@ -49,7 +47,7 @@ class PsychicHttpServer
 
     static void destroy(void *ctx);
 
-    void listen(uint16_t port);
+    virtual void setPort(uint16_t port);
 
     bool isRunning() { return _running; }
     esp_err_t begin() {return start();}

--- a/src/PsychicHttpServer.h
+++ b/src/PsychicHttpServer.h
@@ -26,6 +26,8 @@ class PsychicHttpServer
 
     esp_err_t _start();
     virtual esp_err_t _startServer();
+    virtual esp_err_t _stopServer();
+    bool _running = false;
 
   public:
     PsychicHttpServer();
@@ -49,9 +51,11 @@ class PsychicHttpServer
 
     void listen(uint16_t port);
 
-    virtual esp_err_t begin() {return start();}
-    virtual esp_err_t start();
-    virtual void stop();
+    bool isRunning() { return _running; }
+    esp_err_t begin() {return start();}
+    esp_err_t end() {return stop();}
+    esp_err_t start();
+    esp_err_t stop();
 
 
     PsychicHandler& addHandler(PsychicHandler* handler);

--- a/src/PsychicHttpsServer.cpp
+++ b/src/PsychicHttpsServer.cpp
@@ -48,12 +48,12 @@ esp_err_t PsychicHttpsServer::_startServer()
     return httpd_start(&this->server, &this->config);
 }
 
-void PsychicHttpsServer::stop()
+esp_err_t PsychicHttpsServer::_stopServer()
 {
   if (this->_use_ssl)
-    httpd_ssl_stop(this->server);
+    ret = httpd_ssl_stop(this->server);
   else
-    httpd_stop(this->server);
+    ret = httpd_stop(this->server);
 }
 
 #endif // CONFIG_ESP_HTTPS_SERVER_ENABLE

--- a/src/PsychicHttpsServer.h
+++ b/src/PsychicHttpsServer.h
@@ -16,6 +16,8 @@ class PsychicHttpsServer : public PsychicHttpServer
 {
   protected:
     bool _use_ssl = false;
+    virtual esp_err_t _startServer() override final;
+    virtual esp_err_t _stopServer() override final;
 
   public:
     PsychicHttpsServer();
@@ -25,9 +27,6 @@ class PsychicHttpsServer : public PsychicHttpServer
 
     using PsychicHttpServer::listen; //keep the regular version
     void listen(uint16_t port, const char *cert, const char *private_key);
-
-    virtual esp_err_t _startServer() override final;
-    virtual void stop() override final;
 };
 
 #endif // PsychicHttpsServer_h

--- a/src/PsychicHttpsServer.h
+++ b/src/PsychicHttpsServer.h
@@ -15,18 +15,18 @@
 class PsychicHttpsServer : public PsychicHttpServer
 {
   protected:
-    bool _use_ssl = false;
     virtual esp_err_t _startServer() override final;
     virtual esp_err_t _stopServer() override final;
 
   public:
-    PsychicHttpsServer();
+    PsychicHttpsServer(uint16_t port = 443, const char *cert = nullptr, const char *private_key = nullptr);
     ~PsychicHttpsServer();
 
     httpd_ssl_config_t ssl_config;
 
     using PsychicHttpServer::listen; //keep the regular version
-    void listen(uint16_t port, const char *cert, const char *private_key);
+    virtual void setPort(uint16_t port) override final;
+    void setCertificate(const char *cert, const char *private_key);
 };
 
 #endif // PsychicHttpsServer_h


### PR DESCRIPTION
- Separate port config logic which can be set in constructor or with setPort (aka ESPAsyncWS)
- Separate certificate logic which is only applicable to https
- Removed the use_ssl boolean: if one creates a https server, this is to use ssl. Don't create a https server if this is to use http otherwise it will just confuse users

Note: this PR includes commit from PR #129