### PR TITLE
Fix compilation warnings

### DIFF
--- a/src/PsychicHttpServer.cpp
+++ b/src/PsychicHttpServer.cpp
@@ -110,10 +110,10 @@ esp_err_t PsychicHttpServer::start()
   {
     ESP_LOGD(PH_TAG, "Adding %s meta endpoint", http_method_str((http_method)method));
 
-    httpd_uri_t my_uri{
-      .uri = "*",
-      .method = method,
-      .handler = PsychicHttpServer::requestHandler};
+    httpd_uri_t my_uri;
+    my_uri.uri = "*";
+    my_uri.method = method;
+    my_uri.handler = PsychicHttpServer::requestHandler;
 
     // Register endpoint with ESP-IDF server
     esp_err_t ret = httpd_register_uri_handler(this->server, &my_uri);
@@ -223,13 +223,13 @@ PsychicEndpoint* PsychicHttpServer::on(const char* uri, int method, PsychicHandl
   if (handler->isWebSocket())
   {
     // URI handler structure
-    httpd_uri_t my_uri{
-      .uri = uri,
-      .method = HTTP_GET,
-      .handler = PsychicEndpoint::requestCallback,
-      .user_ctx = endpoint,
-      .is_websocket = handler->isWebSocket(),
-      .supported_subprotocol = handler->getSubprotocol()};
+    httpd_uri_t my_uri;
+    my_uri.uri = uri;
+    my_uri.method = HTTP_GET;
+    my_uri.handler = PsychicEndpoint::requestCallback;
+    my_uri.user_ctx = endpoint;
+    my_uri.is_websocket = handler->isWebSocket();
+    my_uri.supported_subprotocol = handler->getSubprotocol();
 
     // save it to our 'real' handlers for later.
     _esp_idf_endpoints.push_back(my_uri);


### PR DESCRIPTION
```
/Users/mat/Data/Workspace/forks/PsychicHttp/src/PsychicHttpServer.cpp: In member function 'esp_err_t PsychicHttpServer::start()':
/Users/mat/Data/Workspace/forks/PsychicHttp/src/PsychicHttpServer.cpp:116:51: warning: missing initializer for member 'httpd_uri::user_ctx' [-Wmissing-field-initializers]
  116 |       .handler = PsychicHttpServer::requestHandler};
      |                                                   ^
/Users/mat/Data/Workspace/forks/PsychicHttp/src/PsychicHttpServer.cpp:116:51: warning: missing initializer for member 'httpd_uri::is_websocket' [-Wmissing-field-initializers]
/Users/mat/Data/Workspace/forks/PsychicHttp/src/PsychicHttpServer.cpp:116:51: warning: missing initializer for member 'httpd_uri::handle_ws_control_frames' [-Wmissing-field-initializers]
/Users/mat/Data/Workspace/forks/PsychicHttp/src/PsychicHttpServer.cpp:116:51: warning: missing initializer for member 'httpd_uri::supported_subprotocol' [-Wmissing-field-initializers]
/Users/mat/Data/Workspace/forks/PsychicHttp/src/PsychicHttpServer.cpp: In member function 'PsychicEndpoint& PsychicHttpServer::on(const char*, int, PsychicHandler*)':
/Users/mat/Data/Workspace/forks/PsychicHttp/src/PsychicHttpServer.cpp:232:57: warning: missing initializer for member 'httpd_uri::handle_ws_control_frames' [-Wmissing-field-initializers]
  232 |       .supported_subprotocol = handler->getSubprotocol()};
```

On a general note, it would be nice to add `-Wall -Wextra` everywhere in the compilation flags and make sure we run a local build to check, because this is really frustrating getting warnings from libraries in final projects, locations that we do not have control over.