### PR TITLE
Missing reply() override

### DIFF
--- a/src/PsychicRequest.cpp
+++ b/src/PsychicRequest.cpp
@@ -619,6 +619,17 @@ esp_err_t PsychicRequest::reply(int code, const char* contentType, const char* c
   return response.send();
 }
 
+esp_err_t PsychicRequest::reply(int code, const char* contentType, const uint8_t* content, size_t len)
+{
+  PsychicResponse response(this);
+
+  response.setCode(code);
+  response.setContentType(contentType);
+  response.setContent(content, len);
+
+  return response.send();
+}
+
 esp_err_t PsychicRequest::reply(PsychicResponse* response)
 {
   esp_err_t err = response->send();

--- a/src/PsychicRequest.h
+++ b/src/PsychicRequest.h
@@ -116,6 +116,7 @@ class PsychicRequest
     esp_err_t reply(int code);
     esp_err_t reply(const char* content);
     esp_err_t reply(int code, const char* contentType, const char* content);
+    esp_err_t reply(int code, const char* contentType, const uint8_t* content, size_t len);
     esp_err_t reply(PsychicResponse* response);
 
     PsychicResponse* beginReply(int code);


### PR DESCRIPTION
```c++
reply(int code, const char* contentType, const uint8_t* content, size_t len)
```