### PR TITLE
Fix cookie handling which is consuming too much stack memory

### DIFF
--- a/examples/arduino/arduino.ino
+++ b/examples/arduino/arduino.ino
@@ -327,13 +327,14 @@ void setup()
       PsychicResponse response(request);
 
       int counter = 0;
-      if (request->hasCookie("counter"))
+      char cookie[10];
+      size_t size = 10;
+      if (request->getCookie("counter", cookie, &size) == ESP_OK)
       {
-        counter = std::stoi(request->getCookie("counter").c_str());
+        // value is null-terminated.
+        counter = std::stoi(cookie);
         counter++;
       }
-
-      char cookie[10];
       sprintf(cookie, "%d", counter);
 
       response.setCookie("counter", cookie);

--- a/examples/esp-idf/main/main.cpp
+++ b/examples/esp-idf/main/main.cpp
@@ -331,13 +331,14 @@ void setup()
       PsychicResponse response(request);
 
       int counter = 0;
-      if (request->hasCookie("counter"))
+      char cookie[12];
+      size_t size = 12;
+      if (request->getCookie("counter", cookie, &size) == ESP_OK)
       {
-        counter = std::stoi(request->getCookie("counter").c_str());
+        // value is null-terminated.
+        counter = std::stoi(cookie);
         counter++;
       }
-
-      char cookie[12];
       sprintf(cookie, "%d", counter);
 
       response.setCookie("counter", cookie);

--- a/examples/platformio/src/main.cpp
+++ b/examples/platformio/src/main.cpp
@@ -443,13 +443,14 @@ void setup()
       PsychicResponse response(request);
 
       int counter = 0;
-      if (request->hasCookie("counter"))
+      char cookie[14];
+      size_t size = 14;
+      if (request->getCookie("counter", cookie, &size) == ESP_OK)
       {
-        counter = std::stoi(request->getCookie("counter").c_str());
+        // value is null-terminated.
+        counter = std::stoi(cookie);
         counter++;
       }
-
-      char cookie[14];
       sprintf(cookie, "%d", counter);
 
       response.setCookie("counter", cookie);

--- a/src/PsychicCore.h
+++ b/src/PsychicCore.h
@@ -8,10 +8,6 @@
 #define PSYCHIC_HTTP_VERSION_MINOR 1
 #define PSYCHIC_HTTP_VERSION_PATCH 0
 
-#ifndef MAX_COOKIE_SIZE
-  #define MAX_COOKIE_SIZE 512
-#endif
-
 #ifndef FILE_CHUNK_SIZE
   #define FILE_CHUNK_SIZE 8 * 1024
 #endif

--- a/src/PsychicRequest.cpp
+++ b/src/PsychicRequest.cpp
@@ -286,30 +286,14 @@ esp_err_t PsychicRequest::redirect(const char* url)
 
 bool PsychicRequest::hasCookie(const char* key)
 {
-  char cookie[MAX_COOKIE_SIZE];
-  size_t cookieSize = MAX_COOKIE_SIZE;
-  esp_err_t err = httpd_req_get_cookie_val(this->_req, key, cookie, &cookieSize);
-
-  // did we get anything?
-  if (err == ESP_OK)
-    return true;
-  else if (err == ESP_ERR_HTTPD_RESULT_TRUNC)
-    ESP_LOGE(PH_TAG, "cookie too large (%d bytes).\n", cookieSize);
-
-  return false;
+  char buffer;
+  size_t size = 1;
+  return getCookie(key, &buffer, &size) != ESP_ERR_NOT_FOUND;
 }
 
-const String PsychicRequest::getCookie(const char* key)
+esp_err_t PsychicRequest::getCookie(const char* key, char* buffer, size_t* size)
 {
-  char cookie[MAX_COOKIE_SIZE];
-  size_t cookieSize = MAX_COOKIE_SIZE;
-  esp_err_t err = httpd_req_get_cookie_val(this->_req, key, cookie, &cookieSize);
-
-  // did we get anything?
-  if (err == ESP_OK)
-    return String(cookie);
-  else
-    return "";
+  return httpd_req_get_cookie_val(this->_req, key, buffer, size);
 }
 
 void PsychicRequest::loadParams()

--- a/src/PsychicRequest.h
+++ b/src/PsychicRequest.h
@@ -86,7 +86,23 @@ class PsychicRequest
     void setSessionKey(const String& key, const String& value);
 
     bool hasCookie(const char* key);
-    const String getCookie(const char* key);
+
+    /**
+     * @brief   Get the value string of a cookie value from the "Cookie" request headers by cookie name.
+     *
+     * @param[in]       key             The cookie name to be searched in the request
+     * @param[out]      buffer          Pointer to the buffer into which the value of cookie will be copied if the cookie is found
+     * @param[inout]    size            Pointer to size of the user buffer "val". This variable will contain cookie length if
+     *                                  ESP_OK is returned and required buffer length in case ESP_ERR_HTTPD_RESULT_TRUNC is returned.
+     *
+     * @return
+     *  - ESP_OK : Key is found in the cookie string and copied to buffer. The value is null-terminated.
+     *  - ESP_ERR_NOT_FOUND          : Key not found
+     *  - ESP_ERR_INVALID_ARG        : Null arguments
+     *  - ESP_ERR_HTTPD_RESULT_TRUNC : Value string truncated
+     *  - ESP_ERR_NO_MEM             : Memory allocation failure
+     */
+    esp_err_t getCookie(const char* key, char* buffer, size_t* size);
 
     http_method method();       // returns the HTTP method used as enum value (eg. HTTP_GET)
     const String methodStr();   // returns the HTTP method used as a string (eg. "GET")


### PR DESCRIPTION
To consider:
- Allocating so many bytes on stack is a waste of resource
- Cookie length vary greatly: can be very short and very long
- Truncation cannot be handled for long cookie
- Length was only customizable application-wide, so if an app had a huge cookie, it would impact all the other cookie parsing code
- User is responsible to know its cookie length