### PR TITLE
Better way of working

### DIFF
--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
   "name": "PsychicHttp",
-  "version": "1.2.0",
+  "version": "2.0.0",
   "description": "Arduino style wrapper around ESP-IDF HTTP library. HTTP server with SSL + websockets. Works on esp32 and probably esp8266",
   "keywords": "network,http,https,tcp,ssl,tls,websocket,espasyncwebserver",
   "repository": {
@@ -31,11 +31,6 @@
       "owner": "bblanchon",
       "name": "ArduinoJson",
       "version": "^7.0.4"
-    },
-    {
-      "owner": "bblanchon",
-      "name": "ArduinoTrace",
-      "version": "^1.2.0"
     },
     {
       "owner": "plageoj",

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=PsychicHttp
-version=1.2.0
+version=2.0.0
 author=Zach Hoeken <hoeken@gmail.com>
 maintainer=Zach Hoeken <hoeken@gmail.com>
 sentence=PsychicHttp is a robust webserver that supports http/https + websockets.

--- a/platformio.ini
+++ b/platformio.ini
@@ -8,6 +8,11 @@
 ; Please visit documentation for the other options and examples
 ; https://docs.platformio.org/page/projectconf.html
 
+[platformio]
+lib_dir = .
+src_dir = examples/platformio
+; src_dir = examples/arduino
+
 [env]
 platform = espressif32
 framework = arduino
@@ -17,9 +22,9 @@ monitor_port = /dev/ttyACM1
 monitor_speed = 115200
 monitor_filters = esp32_exception_decoder
 lib_deps = 
-    ; hoeken/PsychicHttp
-    ; PIO is not able to consider installed project in CI
-    ../..
+    plageoj/UrlEncode@^1.0.1
+    bblanchon/ArduinoJson@^7.0.4
+    bblanchon/ArduinoTrace@^1.2.0
 board_build.filesystem = littlefs
 build_flags =
     -Wall
@@ -62,3 +67,9 @@ lib_deps = ${env.lib_deps}
 build_flags =
   -D PSY_ENABLE_SDCARD
   -D WAVESHARE_43_TOUCH
+
+[env:dev]
+build_flags =
+  ${env.build_flags}
+  -D CORE_DEBUG_LEVEL=5
+  -D PSY_DEVMODE

--- a/src/PsychicVersion.h
+++ b/src/PsychicVersion.h
@@ -14,11 +14,6 @@
 
 #pragma once
 
-#ifdef __cplusplus
-extern "C"
-{
-#endif
-
 /** Major version number (X.x.x) */
 #define PSYCHIC_VERSION_MAJOR 2
 /** Minor version number (x.X.x) */
@@ -43,14 +38,10 @@ extern "C"
 /**
  * Current PsychicHttp version, as string
  */
-#ifndef df2xstr
-#define df2xstr(s)          #s
+#ifndef PSYCHIC_df2xstr
+#define PSYCHIC_df2xstr(s)          #s
 #endif
-#ifndef df2str
-#define df2str(s)           df2xstr(s)
+#ifndef PSYCHIC_df2str
+#define PSYCHIC_df2str(s)           PSYCHIC_df2xstr(s)
 #endif
-#define PSYCHIC_VERSION_STR df2str(PSYCHIC_VERSION_MAJOR) "." df2str(PSYCHIC_VERSION_MINOR) "." df2str(PSYCHIC_VERSION_PATCH)
-
-#ifdef __cplusplus
-}
-#endif
+#define PSYCHIC_VERSION_STR PSYCHIC_df2str(PSYCHIC_VERSION_MAJOR) "." PSYCHIC_df2str(PSYCHIC_VERSION_MINOR) "." PSYCHIC_df2str(PSYCHIC_VERSION_PATCH)


### PR DESCRIPTION
@hoeken : this is how I use to work in my projects.

I have a platformio file at the root which allows me to use the pio extension right when I open vscode. I don't need to spawn example projects and do hacky symlinks.

Also, having a Platformio file at the root allows to setup different env easily and leverage this file for build. I give you an example here how to automatically run all examples from CI using different env from a pio file:

https://github.com/mathieucarbou/MycilaMQTT/blob/main/.github/workflows/ci.yml#L80-L126

This allows also to have dependencies that are different per env.

All that managed from one file at the root.

I've just updated the pio files in this PR but if it works for you, you can go further to even include parts of esp-idf examples in new env in this root.

And I am just switching the src folder depending on which example I want to test my code with at the moment.