### PR TITLE
Proposal of API change for v2 Feature: Middleware / Filters #161

### DIFF
--- a/benchmark/psychichttp/src/main.cpp
+++ b/benchmark/psychichttp/src/main.cpp
@@ -170,7 +170,7 @@ void setup()
     }
 
     // our index
-    server.on("/", HTTP_GET, [](PsychicRequest* request) { return request->reply(200, "text/html", htmlContent); });
+    server.on("/", HTTP_GET, [](PsychicRequest* request, PsychicResponse* response) { return response->send(200, "text/html", htmlContent); });
 
     // serve static files from LittleFS/www on /
     server.serveStatic("/", LittleFS, "/www/");
@@ -180,7 +180,7 @@ void setup()
       // client->sendMessage("Hello!");
     });
     websocketHandler.onFrame([](PsychicWebSocketRequest* request, httpd_ws_frame* frame) {
-      request->reply(frame);
+      response->send(frame);
       return ESP_OK; });
     server.on("/ws", &websocketHandler);
 
@@ -189,7 +189,7 @@ void setup()
     server.on("/events", &eventSource);
 
     // api - parameters passed in via query eg. /api/endpoint?foo=bar
-    server.on("/api", HTTP_GET, [](PsychicRequest* request) {
+    server.on("/api", HTTP_GET, [](PsychicRequest* request, PsychicResponse* response) {
       //create a response object
       JsonDocument output;
       output["msg"] = "status";
@@ -206,7 +206,7 @@ void setup()
       //serialize and return
       String jsonBuffer;
       serializeJson(output, jsonBuffer);
-      return request->reply(200, "application/json", jsonBuffer.c_str()); });
+      return response->send(200, "application/json", jsonBuffer.c_str()); });
 
     server.begin();
   }

--- a/benchmark/psychichttps/src/main.cpp
+++ b/benchmark/psychichttps/src/main.cpp
@@ -196,7 +196,7 @@ void setup()
 
     // our index
     server.on("/", HTTP_GET, [](PsychicRequest* request)
-              { return request->reply(200, "text/html", htmlContent); });
+              { return response->send(200, "text/html", htmlContent); });
 
     // serve static files from LittleFS/www on /
     server.serveStatic("/", LittleFS, "/www/");
@@ -204,7 +204,7 @@ void setup()
     // a websocket echo server
     websocketHandler.onFrame([](PsychicWebSocketRequest* request, httpd_ws_frame* frame)
                              {
-      request->reply(frame);
+      response->send(frame);
       return ESP_OK; });
     server.on("/ws", &websocketHandler);
 
@@ -227,7 +227,7 @@ void setup()
       //serialize and return
       String jsonBuffer;
       serializeJson(output, jsonBuffer);
-      return request->reply(200, "application/json", jsonBuffer.c_str()); });
+      return response->send(200, "application/json", jsonBuffer.c_str()); });
   }
 }
 

--- a/examples/arduino/arduino.ino
+++ b/examples/arduino/arduino.ino
@@ -211,20 +211,20 @@ void setup()
         //this creates a 2nd server listening on port 80 and redirects all requests HTTPS
         PsychicHttpServer *redirectServer = new PsychicHttpServer();
         redirectServer->config.ctrl_port = 20424; // just a random port different from the default one
-        redirectServer->onNotFound([](PsychicRequest *request) {
+        redirectServer->onNotFound([](PsychicRequest *request, PsychicResponse *response) {
           String url = "https://" + request->host() + request->url();
-          return request->redirect(url.c_str());
+          return response->redirect(url.c_str());
         });
       }
     #endif
 
     //serve static files from LittleFS/www on / only to clients on same wifi network
     //this is where our /index.html file lives
-    server.serveStatic("/", LittleFS, "/www/")->setFilter(ON_STA_FILTER);
+    server.serveStatic("/", LittleFS, "/www/")->addFilter(ON_STA_FILTER);
 
     //serve static files from LittleFS/www-ap on / only to clients on SoftAP
     //this is where our /index.html file lives
-    server.serveStatic("/", LittleFS, "/www-ap/")->setFilter(ON_AP_FILTER);
+    server.serveStatic("/", LittleFS, "/www-ap/")->addFilter(ON_AP_FILTER);
 
     //serve static files from LittleFS/img on /img
     //it's more efficient to serve everything from a single www directory, but this is also possible.
@@ -235,16 +235,16 @@ void setup()
 
     //example callback everytime a connection is opened
     server.onOpen([](PsychicClient *client) {
-      Serial.printf("[http] connection #%u connected from %s\n", client->socket(), client->localIP().toString());
+      Serial.printf("[http] connection #%u connected from %s\n", client->socket(), client->localIP().toString().c_str());
     });
 
     //example callback everytime a connection is closed
     server.onClose([](PsychicClient *client) {
-      Serial.printf("[http] connection #%u closed from %s\n", client->socket(), client->localIP().toString());
+      Serial.printf("[http] connection #%u closed from %s\n", client->socket(), client->localIP().toString().c_str());
     });
 
     //api - json message passed in as post body
-    server.on("/api", HTTP_POST, [](PsychicRequest *request)
+    server.on("/api", HTTP_POST, [](PsychicRequest *request, PsychicResponse *response)
     {
       //load our JSON request
       StaticJsonDocument<1024> json;
@@ -267,18 +267,18 @@ void setup()
       //serialize and return
       String jsonBuffer;
       serializeJson(output, jsonBuffer);
-      return request->reply(200, "application/json", jsonBuffer.c_str());
+      return response->send(200, "application/json", jsonBuffer.c_str());
     });
 
     //api - parameters passed in via query eg. /api/endpoint?foo=bar
-    server.on("/ip", HTTP_GET, [](PsychicRequest *request)
+    server.on("/ip", HTTP_GET, [](PsychicRequest *request, PsychicResponse *response)
     {
       String output = "Your IP is: " + request->client()->remoteIP().toString();
-      return request->reply(output.c_str());
+      return response->send(output.c_str());
     });
 
     //api - parameters passed in via query eg. /api/endpoint?foo=bar
-    server.on("/api", HTTP_GET, [](PsychicRequest *request)
+    server.on("/api", HTTP_GET, [](PsychicRequest *request, PsychicResponse *response)
     {
       //create a response object
       StaticJsonDocument<128> output;
@@ -296,39 +296,37 @@ void setup()
       //serialize and return
       String jsonBuffer;
       serializeJson(output, jsonBuffer);
-      return request->reply(200, "application/json", jsonBuffer.c_str());
+      return response->send(200, "application/json", jsonBuffer.c_str());
     });
 
     //how to redirect a request
-    server.on("/redirect", HTTP_GET, [](PsychicRequest *request)
+    server.on("/redirect", HTTP_GET, [](PsychicRequest *request, PsychicResponse *response)
     {
-      return request->redirect("/alien.png");
+      return response->redirect("/alien.png");
     });
 
     //how to do basic auth
-    server.on("/auth-basic", HTTP_GET, [](PsychicRequest *request)
+    server.on("/auth-basic", HTTP_GET, [](PsychicRequest *request, PsychicResponse *response)
     {
       if (!request->authenticate(app_user, app_pass))
         return request->requestAuthentication(BASIC_AUTH, app_name, "You must log in.");
-      return request->reply("Auth Basic Success!");
+      return response->send("Auth Basic Success!");
     });
 
     //how to do digest auth
-    server.on("/auth-digest", HTTP_GET, [](PsychicRequest *request)
+    server.on("/auth-digest", HTTP_GET, [](PsychicRequest *request, PsychicResponse *response)
     {
       if (!request->authenticate(app_user, app_pass))
         return request->requestAuthentication(DIGEST_AUTH, app_name, "You must log in.");
-      return request->reply("Auth Digest Success!");
+      return response->send("Auth Digest Success!");
     });
 
     //example of getting / setting cookies
-    server.on("/cookies", HTTP_GET, [](PsychicRequest *request)
+    server.on("/cookies", HTTP_GET, [](PsychicRequest *request, PsychicResponse *response)
     {
-      PsychicResponse response(request);
-
       int counter = 0;
-      char cookie[10];
-      size_t size = 10;
+      char cookie[14];
+      size_t size = 14;
       if (request->getCookie("counter", cookie, &size) == ESP_OK)
       {
         // value is null-terminated.
@@ -337,25 +335,25 @@ void setup()
       }
       sprintf(cookie, "%d", counter);
 
-      response.setCookie("counter", cookie);
-      response.setContent(cookie);
-      return response.send();
+      response->setCookie("counter", cookie);
+      response->setContent(cookie);
+      return response->send();
     });
 
     //example of getting POST variables
-    server.on("/post", HTTP_POST, [](PsychicRequest *request)
+    server.on("/post", HTTP_POST, [](PsychicRequest *request, PsychicResponse *response)
     {
       String output;
       output += "Param 1: " + request->getParam("param1")->value() + "<br/>\n";
       output += "Param 2: " + request->getParam("param2")->value() + "<br/>\n";
 
-      return request->reply(output.c_str());
+      return response->send(output.c_str());
     });
 
     //you can set up a custom 404 handler.
-    server.onNotFound([](PsychicRequest *request)
+    server.onNotFound([](PsychicRequest *request, PsychicResponse *response)
     {
-      return request->reply(404, "text/html", "Custom 404 Handler");
+      return response->send(404, "text/html", "Custom 404 Handler");
     });
 
     //handle a very basic upload as post body
@@ -389,12 +387,12 @@ void setup()
     });
 
     //gets called after upload has been handled
-    uploadHandler->onRequest([](PsychicRequest *request)
+    uploadHandler->onRequest([](PsychicRequest *request, PsychicResponse *response)
     {
       String url = "/" + request->getFilename();
       String output = "<a href=\"" + url + "\">" + url + "</a>";
 
-      return request->reply(output.c_str());
+      return response->send(output.c_str());
     });
 
     //wildcard basic file upload - POST to /upload/filename.ext
@@ -431,7 +429,7 @@ void setup()
     });
 
     //gets called after upload has been handled
-    multipartHandler->onRequest([](PsychicRequest *request)
+    multipartHandler->onRequest([](PsychicRequest *request, PsychicResponse *response)
     {
       PsychicWebParameter *file = request->getParam("file_upload");
 
@@ -443,7 +441,7 @@ void setup()
       output += "Param 1: " + request->getParam("param1")->value() + "<br/>\n";
       output += "Param 2: " + request->getParam("param2")->value() + "<br/>\n";
       
-      return request->reply(output.c_str());
+      return response->send(output.c_str());
     });
 
     //wildcard basic file upload - POST to /upload/filename.ext
@@ -451,7 +449,7 @@ void setup()
 
     //a websocket echo server
     websocketHandler.onOpen([](PsychicWebSocketClient *client) {
-      Serial.printf("[socket] connection #%u connected from %s\n", client->socket(), client->localIP().toString());
+      Serial.printf("[socket] connection #%u connected from %s\n", client->socket(), client->localIP().toString().c_str());
       client->sendMessage("Hello!");
     });
     websocketHandler.onFrame([](PsychicWebSocketRequest *request, httpd_ws_frame *frame) {
@@ -459,17 +457,17 @@ void setup()
         return request->reply(frame);
     });
     websocketHandler.onClose([](PsychicWebSocketClient *client) {
-      Serial.printf("[socket] connection #%u closed from %s\n", client->socket(), client->localIP().toString());
+      Serial.printf("[socket] connection #%u closed from %s\n", client->socket(), client->localIP().toString().c_str());
     });
     server.on("/ws", &websocketHandler);
 
     //EventSource server
     eventSource.onOpen([](PsychicEventSourceClient *client) {
-      Serial.printf("[eventsource] connection #%u connected from %s\n", client->socket(), client->localIP().toString());
+      Serial.printf("[eventsource] connection #%u connected from %s\n", client->socket(), client->localIP().toString().c_str());
       client->send("Hello user!", NULL, millis(), 1000);
     });
     eventSource.onClose([](PsychicEventSourceClient *client) {
-      Serial.printf("[eventsource] connection #%u closed from %s\n", client->socket(), client->localIP().toString());
+      Serial.printf("[eventsource] connection #%u closed from %s\n", client->socket(), client->localIP().toString().c_str());
     });
     server.on("/events", &eventSource);
   }
@@ -482,10 +480,10 @@ void loop()
 {
   if (millis() - lastUpdate > 2000)
   {
-    sprintf(output, "Millis: %d\n", millis());
+    sprintf(output, "Millis: %lu\n", millis());
     websocketHandler.sendAll(output);
 
-    sprintf(output, "%d", millis());
+    sprintf(output, "%lu", millis());
     eventSource.send(output, "millis", millis(), 0);
 
     lastUpdate = millis();

--- a/examples/arduino/arduino_captive_portal/README.md
+++ b/examples/arduino/arduino_captive_portal/README.md
@@ -28,7 +28,7 @@ public:
   esp_err_t handleRequest(PsychicRequest *request) {   
    //PsychicFileResponse response(request, LittleFS, "/captiveportal.html"); // uncomment : for captive portal page, if any, eg "captiveportal.html"
    //return response.send();                                                 // uncomment : return captive portal page
-   return request->reply(200,"text/html","Welcome to captive portal !");     // simple text, comment if captive portal page
+   return response->send(200,"text/html","Welcome to captive portal !");     // simple text, comment if captive portal page
   }
 };
 CaptiveRequestHandler *captivehandler=NULL;             // handler for captive portal

--- a/examples/arduino/arduino_captive_portal/arduino_captive_portal.ino
+++ b/examples/arduino/arduino_captive_portal/arduino_captive_portal.ino
@@ -14,7 +14,7 @@
 #include <ESPmDNS.h>
 #include <PsychicHttp.h>
 
-char* TAG = "CAPTPORT";
+#define TAG "CAPTPORT"
 
 // captiveportal
 // credits https://github.com/me-no-dev/ESPAsyncWebServer/blob/master/examples/CaptivePortal/CaptivePortal.ino
@@ -29,10 +29,10 @@ public:
     // ... if needed some tests ... return(false);
     return true;  // activate captive portal
   }
-  esp_err_t handleRequest(PsychicRequest *request) {   
+  esp_err_t handleRequest(PsychicRequest *request, PsychicResponse *response) {   
    //PsychicFileResponse response(request, LittleFS, "/captiveportal.html"); // uncomment : for captive portal page, if any, eg "captiveportal.html"
    //return response.send();                                                 // uncomment : return captive portal page
-   return request->reply(200,"text/html","Welcome to captive portal !");     // simple text, comment if captive portal page
+   return response->send(200,"text/html","Welcome to captive portal !");     // simple text, comment if captive portal page
   }
 };
 CaptiveRequestHandler *captivehandler=NULL;             // handler for captive portal

--- a/examples/arduino/arduino_ota/arduino_ota.ino
+++ b/examples/arduino/arduino_ota/arduino_ota.ino
@@ -8,7 +8,7 @@
   CONDITIONS OF ANY KIND, either express or implied.
   
 */
-char *TAG = "OTA"; // ESP_LOG tag
+#define TAG "OTA" // ESP_LOG tag
 
 // PsychicHttp
 #include <Arduino.h>
@@ -108,8 +108,8 @@ void setup()
     
     //you can set up a custom 404 handler.
     // curl -i http://psychic.local/404
-    server.onNotFound([](PsychicRequest *request) {
-      return request->reply(404, "text/html", "Custom 404 Handler");
+    server.onNotFound([](PsychicRequest *request, PsychicResponse *response) {
+      return response->send(404, "text/html", "Custom 404 Handler");
     });
 
     // OTA
@@ -176,34 +176,34 @@ void setup()
     }
     });  // end onUpload
 
-    updateHandler->onRequest([](PsychicRequest *request) {  // triggered when update is completed (either OK or KO) and returns request's response (important)
+    updateHandler->onRequest([](PsychicRequest *request, PsychicResponse *response) {  // triggered when update is completed (either OK or KO) and returns request's response (important)
       String result; // request result
       // code below is executed when update is finished
       if (!Update.hasError()) { // update is OK
         ESP_LOGI(TAG,"Update code or data OK Update.errorString() %s", Update.errorString());
         result = "<b style='color:green'>Update done for file.</b>";
-        return request->reply(200,"text/html",result.c_str());
+        return response->send(200,"text/html",result.c_str());
         // ESP.restart();                                              // restart ESP if needed
       } // end update is OK
       else { // update is KO, send request with pretty print error
         result = " Update.errorString() " + String(Update.errorString()); 
         ESP_LOGE(TAG,"ERROR : error %s",result.c_str());    
-        return request->reply(500, "text/html", result.c_str());
+        return response->send(500, "text/html", result.c_str());
       } // end update is KO
     });
 
-    server.on("/update", HTTP_GET, [](PsychicRequest*request){
-      PsychicFileResponse response(request, LittleFS, "/update.html");
+    server.on("/update", HTTP_GET, [](PsychicRequest*request, PsychicResponse *res){
+      PsychicFileResponse response(res, LittleFS, "/update.html");
       return response.send();
     });
     
     server.on("/update", HTTP_POST, updateHandler);
 
-    server.on("/restart", HTTP_POST, [](PsychicRequest *request) {
+    server.on("/restart", HTTP_POST, [](PsychicRequest *request, PsychicResponse *response) {
       String output = "<b style='color:green'>Restarting ...</b>";
       ESP_LOGI(TAG,"%s",output.c_str());      
       esprestart=true;
-      return request->reply(output.c_str());      
+      return response->send(output.c_str());      
     });    
  } // end onRequest
 

--- a/examples/websockets/src/main.cpp
+++ b/examples/websockets/src/main.cpp
@@ -139,7 +139,7 @@ void setup()
 
     // this is where our /index.html file lives
     //  curl -i http://psychic.local/
-    PsychicStaticFileHandler* handler = server.serveStatic("/", LittleFS, "/www/");
+    server.serveStatic("/", LittleFS, "/www/");
 
     // a websocket echo server
     //  npm install -g wscat
@@ -216,7 +216,7 @@ void loop()
   // send a periodic update to all clients
   if (millis() - lastUpdate > 2000)
   {
-    sprintf(output, "Millis: %d\n", millis());
+    sprintf(output, "Millis: %lu\n", millis());
     websocketHandler.sendAll(output);
 
     lastUpdate = millis();

--- a/platformio.ini
+++ b/platformio.ini
@@ -10,8 +10,12 @@
 [platformio]
 lib_dir = .
 
+
 src_dir = examples/platformio/src
 data_dir = examples/platformio/data
+
+; src_dir = examples/websockets/src
+; data_dir = examples/websockets/data
 
 ; src_dir = examples/arduino
 ; data_dir = examples/arduino/data
@@ -28,14 +32,21 @@ framework = arduino
 board = esp32-s3-devkitc-1
 monitor_speed = 115200
 monitor_filters = esp32_exception_decoder
+board_build.filesystem = littlefs
 lib_deps = 
     bblanchon/ArduinoJson
     plageoj/UrlEncode
 lib_ignore =
     examples
 build_flags =
+    -frtti
     -Wall
     -Wextra
+    -Og
+    -D CONFIG_ARDUHAL_LOG_COLORS
+    -D CORE_DEBUG_LEVEL=ARDUHAL_LOG_LEVEL_VERBOSE
+build_unflags =
+    -fno-rtti
 
 [env:arduino2]
 platform = espressif32@6.8.1
@@ -70,3 +81,7 @@ build_flags =
 [env:pioarduino-c6]
 platform = https://github.com/pioarduino/platform-espressif32/releases/download/51.03.04/platform-espressif32.zip
 board = esp32-c6-devkitc-1
+
+[env:mathieu]
+platform = https://github.com/pioarduino/platform-espressif32/releases/download/51.03.04/platform-espressif32.zip
+board = esp32dev

--- a/src/PsychicCore.h
+++ b/src/PsychicCore.h
@@ -49,20 +49,20 @@ class PsychicRequest;
 class PsychicResponse;
 class PsychicWebSocketRequest;
 class PsychicClient;
-class PsychicMiddlewareChain;
 
 // filter function definition
 typedef std::function<bool(PsychicRequest* request)> PsychicRequestFilterFunction;
 
 // middleware function definition
-typedef std::function<bool(PsychicMiddlewareChain *chain, PsychicRequest* request, PsychicResponse* response)> PsychicMiddlewareFunction;
+typedef std::function<esp_err_t(PsychicRequest* request, PsychicResponse* response)> PsychicMiddlewareCallback;
+typedef std::function<esp_err_t(PsychicMiddlewareCallback next, PsychicRequest* request, PsychicResponse* response)> PsychicMiddlewareFunction;
 
 // client connect callback
 typedef std::function<void(PsychicClient* client)> PsychicClientCallback;
 
 // callback definitions
-typedef std::function<esp_err_t(PsychicRequest* request)> PsychicHttpRequestCallback;
-typedef std::function<esp_err_t(PsychicRequest* request, JsonVariant& json)> PsychicJsonRequestCallback;
+typedef std::function<esp_err_t(PsychicRequest* request, PsychicResponse* response)> PsychicHttpRequestCallback;
+typedef std::function<esp_err_t(PsychicRequest* request, PsychicResponse* response, JsonVariant& json)> PsychicJsonRequestCallback;
 typedef std::function<esp_err_t(PsychicRequest* request, const String& filename, uint64_t index, uint8_t* data, size_t len, bool final)> PsychicUploadCallback;
 
 struct HTTPHeader {

--- a/src/PsychicEndpoint.h
+++ b/src/PsychicEndpoint.h
@@ -4,6 +4,7 @@
 #include "PsychicCore.h"
 
 class PsychicHandler;
+class PsychicMiddleware;
 
 #ifdef ENABLE_ASYNC
   #include "async_worker.h"
@@ -32,8 +33,14 @@ class PsychicEndpoint
 
     bool matches(const char* uri);
 
-    PsychicEndpoint* setFilter(PsychicRequestFilterFunction fn);
-    PsychicEndpoint* setAuthentication(const char* username, const char* password, HTTPAuthMethod method = BASIC_AUTH, const char* realm = "", const char* authFailMsg = "");
+    // called to process this endpoint with its middleware chain
+    esp_err_t process(PsychicRequest* request, PsychicResponse* response);
+
+    PsychicEndpoint* addFilter(PsychicRequestFilterFunction fn);
+
+    PsychicEndpoint* addMiddleware(PsychicMiddleware* middleware);
+    PsychicEndpoint* addMiddleware(PsychicMiddlewareFunction fn);
+    bool removeMiddleware(PsychicMiddleware* middleware);
 
     String uri();
 

--- a/src/PsychicEventSource.cpp
+++ b/src/PsychicEventSource.cpp
@@ -50,10 +50,10 @@ PsychicEventSourceClient* PsychicEventSource::getClient(PsychicClient* client)
   return getClient(client->socket());
 }
 
-esp_err_t PsychicEventSource::handleRequest(PsychicRequest* request)
+esp_err_t PsychicEventSource::handleRequest(PsychicRequest* request, PsychicResponse* resp)
 {
   // start our open ended HTTP response
-  PsychicEventSourceResponse response(request);
+  PsychicEventSourceResponse response(resp);
   esp_err_t err = response.send();
 
   // lookup our client
@@ -234,8 +234,7 @@ void PsychicEventSourceClient::_sendEventSentCallback(esp_err_t err, int socket,
 // PsychicEventSourceResponse
 /*****************************************/
 
-PsychicEventSourceResponse::PsychicEventSourceResponse(PsychicRequest* request)
-    : PsychicResponse(request)
+PsychicEventSourceResponse::PsychicEventSourceResponse(PsychicResponse* response) : PsychicResponseDelegate(response)
 {
 }
 
@@ -258,7 +257,7 @@ esp_err_t PsychicEventSourceResponse::send()
 
   int result;
   do {
-    result = httpd_send(_request->request(), out.c_str(), out.length());
+    result = httpd_send(request(), out.c_str(), out.length());
   } while (result == HTTPD_SOCK_ERR_TIMEOUT);
 
   if (result < 0)

--- a/src/PsychicEventSource.h
+++ b/src/PsychicEventSource.h
@@ -80,16 +80,16 @@ class PsychicEventSource : public PsychicHandler
     PsychicEventSource* onOpen(PsychicEventSourceClientCallback fn);
     PsychicEventSource* onClose(PsychicEventSourceClientCallback fn);
 
-    esp_err_t handleRequest(PsychicRequest* request) override final;
+    esp_err_t handleRequest(PsychicRequest* request, PsychicResponse* response) override final;
 
     void send(const char* message, const char* event = NULL, uint32_t id = 0, uint32_t reconnect = 0);
 };
 
-class PsychicEventSourceResponse : public PsychicResponse
+class PsychicEventSourceResponse : public PsychicResponseDelegate
 {
   public:
-    PsychicEventSourceResponse(PsychicRequest* request);
-    virtual esp_err_t send() override;
+    PsychicEventSourceResponse(PsychicResponse* response);
+    esp_err_t send();
 };
 
 String generateEventMessage(const char* message, const char* event, uint32_t id, uint32_t reconnect);

--- a/src/PsychicFileResponse.h
+++ b/src/PsychicFileResponse.h
@@ -6,18 +6,18 @@
 
 class PsychicRequest;
 
-class PsychicFileResponse : public PsychicResponse
+class PsychicFileResponse : public PsychicResponseDelegate
 {
     using File = fs::File;
     using FS = fs::FS;
 
-  private:
+  protected:
     File _content;
-    void _setContentType(const String& path);
+    void _setContentTypeFromPath(const String& path);
 
   public:
-    PsychicFileResponse(PsychicRequest* request, FS& fs, const String& path, const String& contentType = String(), bool download = false);
-    PsychicFileResponse(PsychicRequest* request, File content, const String& path, const String& contentType = String(), bool download = false);
+    PsychicFileResponse(PsychicResponse* response, FS& fs, const String& path, const String& contentType = String(), bool download = false);
+    PsychicFileResponse(PsychicResponse* response, File content, const String& path, const String& contentType = String(), bool download = false);
     ~PsychicFileResponse();
     esp_err_t send();
 };

--- a/src/PsychicHttp.h
+++ b/src/PsychicHttp.h
@@ -19,6 +19,7 @@
 #include "PsychicUploadHandler.h"
 #include "PsychicWebSocket.h"
 #include <http_status.h>
+#include "PsychicMiddlewares.h"
 
 #ifdef ENABLE_ASYNC
   #include "async_worker.h"

--- a/src/PsychicJson.h
+++ b/src/PsychicJson.h
@@ -30,7 +30,7 @@ constexpr const char* JSON_MIMETYPE = "application/json";
  * Json Response
  * */
 
-class PsychicJsonResponse : public PsychicResponse
+class PsychicJsonResponse : public PsychicResponseDelegate
 {
   protected:
 #ifdef ARDUINOJSON_5_COMPATIBILITY
@@ -46,11 +46,11 @@ class PsychicJsonResponse : public PsychicResponse
 
   public:
 #ifdef ARDUINOJSON_5_COMPATIBILITY
-    PsychicJsonResponse(PsychicRequest* request, bool isArray = false);
+    PsychicJsonResponse(PsychicResponse* response, bool isArray = false);
 #elif ARDUINOJSON_VERSION_MAJOR == 6
-    PsychicJsonResponse(PsychicRequest* request, bool isArray = false, size_t maxJsonBufferSize = DYNAMIC_JSON_DOCUMENT_SIZE);
+    PsychicJsonResponse(PsychicResponse* response, bool isArray = false, size_t maxJsonBufferSize = DYNAMIC_JSON_DOCUMENT_SIZE);
 #else
-    PsychicJsonResponse(PsychicRequest* request, bool isArray = false);
+    PsychicJsonResponse(PsychicResponse* response, bool isArray = false);
 #endif
 
     ~PsychicJsonResponse()
@@ -60,7 +60,7 @@ class PsychicJsonResponse : public PsychicResponse
     JsonVariant& getRoot();
     size_t getLength();
 
-    virtual esp_err_t send() override;
+    esp_err_t send();
 };
 
 class PsychicJsonHandler : public PsychicWebHandler
@@ -84,7 +84,7 @@ class PsychicJsonHandler : public PsychicWebHandler
 #endif
 
     void onRequest(PsychicJsonRequestCallback fn);
-    virtual esp_err_t handleRequest(PsychicRequest* request) override;
+    virtual esp_err_t handleRequest(PsychicRequest* request, PsychicResponse* response) override;
 };
 
 #endif

--- a/src/PsychicMiddleware.cpp
+++ b/src/PsychicMiddleware.cpp
@@ -3,15 +3,11 @@
 #include "PsychicRequest.h"
 #include "PsychicResponse.h"
 
-PsychicMiddleware::PsychicMiddleware(PsychicMiddlewareFunction callback) :
-  _callback(callback)
-  {
-  }
-
-PsychicMiddleware::~PsychicMiddleware() {}
-
-void PsychicMiddleware::run(PsychicMiddlewareChain *chain, PsychicRequest *request, PsychicResponse *response)
+PsychicMiddlewareClosure::PsychicMiddlewareClosure(PsychicMiddlewareFunction fn) : _fn(fn)
 {
-  if (_callback)
-    _callback(chain, request, response);
+  assert(_fn);
+}
+esp_err_t PsychicMiddlewareClosure::run(PsychicMiddlewareCallback next, PsychicRequest* request, PsychicResponse* response)
+{
+  return _fn(next, request, response);
 }

--- a/src/PsychicMiddleware.h
+++ b/src/PsychicMiddleware.h
@@ -4,22 +4,26 @@
 #include "PsychicCore.h"
 #include "PsychicRequest.h"
 #include "PsychicResponse.h"
-#include "PsychicMiddlewareChain.h"
 
 /*
  * PsychicMiddleware :: fancy callback wrapper for handling requests and responses.
  * */
 
-class PsychicMiddleware {
+class PsychicMiddleware
+{
   public:
-    //void *_context;
-    String _name;
-    PsychicMiddlewareFunction _callback;
+    virtual ~PsychicMiddleware() {}
+    virtual esp_err_t run(PsychicMiddlewareCallback next, PsychicRequest* request, PsychicResponse* response) = 0;
+};
 
-    PsychicMiddleware(PsychicMiddlewareFunction middleware);
-    virtual ~PsychicMiddleware();
+class PsychicMiddlewareClosure : public PsychicMiddleware
+{
+  protected:
+    PsychicMiddlewareFunction _fn;
 
-    void run(PsychicMiddlewareChain *chain, PsychicRequest *request, PsychicResponse *response);
+  public:
+    PsychicMiddlewareClosure(PsychicMiddlewareFunction fn);
+    esp_err_t run(PsychicMiddlewareCallback next, PsychicRequest* request, PsychicResponse* response) override;
 };
 
 #endif

--- a/src/PsychicMiddlewareChain.h
+++ b/src/PsychicMiddlewareChain.h
@@ -6,27 +6,24 @@
 #include "PsychicResponse.h"
 #include "PsychicMiddleware.h"
 
-class PsychicMiddleware;
-
 /*
  * PsychicMiddlewareChain - handle tracking and executing our chain of middleware objects
  * */
 
-class PsychicMiddlewareChain {
+class PsychicMiddlewareChain
+{
   protected:
     std::list<PsychicMiddleware*> _middleware;
-    std::list<PsychicMiddleware*>::iterator _iterator;
-    PsychicRequest* _request;
-    PsychicResponse* _response;
-    boolean _finished = false;
 
   public:
     PsychicMiddlewareChain();
     virtual ~PsychicMiddlewareChain();
 
     void add(PsychicMiddleware* middleware);
-    bool run(PsychicRequest *request, PsychicResponse *response);
-    void next();
+    void add(PsychicMiddlewareFunction fn);
+    bool remove(PsychicMiddleware* middleware);
+
+    esp_err_t run(PsychicRequest* request, PsychicResponse* response, PsychicMiddlewareCallback finalizer);
 };
 
 #endif

--- a/src/PsychicMiddlewares.h
+++ b/src/PsychicMiddlewares.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include "PsychicMiddleware.h"
+
+class AuthcMiddleware : public PsychicMiddleware
+{
+  protected:
+    String _username;
+    String _password;
+    HTTPAuthMethod _method;
+    String _realm;
+    String _authFailMsg;
+    bool _authc = false;
+
+  public:
+    AuthcMiddleware(const char* username, const char* password, HTTPAuthMethod method = BASIC_AUTH, const char* realm = "", const char* authFailMsg = "")
+        : _username(username), _password(password), _method(method), _realm(realm), _authFailMsg(authFailMsg), _authc(!_username.isEmpty() && !_password.isEmpty()) {}
+
+    esp_err_t run(PsychicMiddlewareCallback next, PsychicRequest* request, PsychicResponse* response) override
+    {
+      if (_authc && !request->authenticate(_username.c_str(), _password.c_str())) {
+        return request->requestAuthentication(_method, _realm.c_str(), _authFailMsg.c_str());
+      }
+      return next(request, response);
+    }
+};
+
+class PermissiveCorsMiddleware : public PsychicMiddleware
+{
+  public:
+    esp_err_t run(PsychicMiddlewareCallback next, PsychicRequest* request, PsychicResponse* response) override
+    {
+      // gives the chance to other most important middleware to run first
+      esp_err_t ret = next(request, response);
+      // add CORS headers
+      if (ret == ESP_OK && request->hasHeader("Origin")) {
+        response->addHeader("Access-Control-Allow-Origin", "*");
+        response->addHeader("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS");
+        response->addHeader("Access-Control-Allow-Headers", "Content-Type, Authorization, Accept");
+        response->addHeader("Access-Control-Max-Age", "86400");
+      }
+      return ret;
+    }
+};

--- a/src/PsychicRequest.cpp
+++ b/src/PsychicRequest.cpp
@@ -272,15 +272,6 @@ bool PsychicRequest::isMultipart()
   return (this->contentType().indexOf("multipart/form-data") >= 0);
 }
 
-esp_err_t PsychicRequest::redirect(const char* url)
-{
-  PsychicResponse response(this);
-  response.setCode(301);
-  response.addHeader("Location", url);
-
-  return response.send();
-}
-
 bool PsychicRequest::hasCookie(const char* key, size_t* size)
 {
   char buffer;
@@ -601,88 +592,4 @@ esp_err_t PsychicRequest::requestAuthentication(HTTPAuthMethod mode, const char*
   response.setContentType("text/html");
   response.setContent(authStr.c_str());
   return response.send();
-}
-
-esp_err_t PsychicRequest::reply(int code)
-{
-  PsychicResponse response(this);
-
-  response.setCode(code);
-  response.setContentType("text/plain");
-  response.setContent(http_status_reason(code));
-
-  return response.send();
-}
-
-esp_err_t PsychicRequest::reply(const char* content)
-{
-  PsychicResponse response(this);
-
-  response.setCode(200);
-  response.setContentType("text/html");
-  response.setContent(content);
-
-  return response.send();
-}
-
-esp_err_t PsychicRequest::reply(int code, const char* contentType, const char* content)
-{
-  PsychicResponse response(this);
-
-  response.setCode(code);
-  response.setContentType(contentType);
-  response.setContent(content);
-
-  return response.send();
-}
-
-esp_err_t PsychicRequest::reply(int code, const char* contentType, const uint8_t* content, size_t len)
-{
-  PsychicResponse response(this);
-
-  response.setCode(code);
-  response.setContentType(contentType);
-  response.setContent(content, len);
-
-  return response.send();
-}
-
-esp_err_t PsychicRequest::reply(PsychicResponse* response)
-{
-  esp_err_t err = response->send();
-  delete response;
-  return err;
-}
-
-PsychicResponse* PsychicRequest::beginReply(int code)
-{
-  PsychicResponse* response = new PsychicResponse(this);
-  response->setCode(code);
-  return response;
-}
-
-PsychicResponse* PsychicRequest::beginReply(int code, const char* contentType)
-{
-  PsychicResponse* response = new PsychicResponse(this);
-  response->setCode(code);
-  response->setContentType(contentType);
-  return response;
-}
-
-PsychicResponse* PsychicRequest::beginReply(int code, const char* contentType, const char* content)
-{
-  PsychicResponse* response = new PsychicResponse(this);
-  response->setCode(code);
-  response->setContentType(contentType);
-  response->setContent(content);
-  return response;
-}
-
-PsychicResponse* PsychicRequest::beginReply(int code, const char* contentType, const uint8_t* content, size_t len)
-{
-  PsychicResponse* response = new PsychicResponse(this);
-  response->setCode(code);
-  response->setContentType(contentType);
-  response->setContent(content, len);
-  return response;
 }

--- a/src/PsychicRequest.h
+++ b/src/PsychicRequest.h
@@ -5,7 +5,6 @@
 #include "PsychicCore.h"
 #include "PsychicEndpoint.h"
 #include "PsychicHttpServer.h"
-#include "PsychicResponse.h"
 #include "PsychicWebParameter.h"
 
 #ifdef PSY_ENABLE_REGEX
@@ -137,18 +136,6 @@ class PsychicRequest
 
     bool authenticate(const char* username, const char* password);
     esp_err_t requestAuthentication(HTTPAuthMethod mode, const char* realm, const char* authFailMsg);
-
-    esp_err_t redirect(const char* url);
-    esp_err_t reply(int code);
-    esp_err_t reply(const char* content);
-    esp_err_t reply(int code, const char* contentType, const char* content);
-    esp_err_t reply(int code, const char* contentType, const uint8_t* content, size_t len);
-    esp_err_t reply(PsychicResponse* response);
-
-    PsychicResponse* beginReply(int code);
-    PsychicResponse* beginReply(int code, const char* contentType);
-    PsychicResponse* beginReply(int code, const char* contentType, const char* content);
-    PsychicResponse* beginReply(int code, const char* contentType, const uint8_t* content, size_t len);
 };
 
 #endif // PsychicRequest_h

--- a/src/PsychicResponse.cpp
+++ b/src/PsychicResponse.cpp
@@ -5,6 +5,7 @@
 PsychicResponse::PsychicResponse(PsychicRequest* request) : _request(request),
                                                             _code(200),
                                                             _status(""),
+                                                            _contentType(emptyString),
                                                             _contentLength(0),
                                                             _body("")
 {
@@ -72,7 +73,7 @@ void PsychicResponse::setCode(int code)
 
 void PsychicResponse::setContentType(const char* contentType)
 {
-  httpd_resp_set_type(_request->request(), contentType);
+  _contentType = contentType;
 }
 
 void PsychicResponse::setContent(const char* content)
@@ -103,6 +104,9 @@ esp_err_t PsychicResponse::send()
   sprintf(_status, "%u %s", _code, http_status_reason(_code));
   httpd_resp_set_status(_request->request(), _status);
 
+  // set the content type
+  httpd_resp_set_type(_request->request(), _contentType.c_str());
+
   // our headers too
   this->sendHeaders();
 
@@ -126,15 +130,13 @@ void PsychicResponse::sendHeaders()
 esp_err_t PsychicResponse::sendChunk(uint8_t* chunk, size_t chunksize)
 {
   /* Send the buffer contents as HTTP response chunk */
-  esp_err_t err = httpd_resp_send_chunk(this->_request->request(), (char*)chunk, chunksize);
+  ESP_LOGD(PH_TAG, "Sending chunk: %d", chunksize);
+  esp_err_t err = httpd_resp_send_chunk(request(), (char*)chunk, chunksize);
   if (err != ESP_OK) {
     ESP_LOGE(PH_TAG, "File sending failed (%s)", esp_err_to_name(err));
 
     /* Abort sending file */
     httpd_resp_sendstr_chunk(this->_request->request(), NULL);
-
-    /* Respond with 500 Internal Server Error */
-    httpd_resp_send_err(this->_request->request(), HTTPD_500_INTERNAL_SERVER_ERROR, "Failed to send file");
   }
 
   return err;
@@ -144,4 +146,63 @@ esp_err_t PsychicResponse::finishChunking()
 {
   /* Respond with an empty chunk to signal HTTP response completion */
   return httpd_resp_send_chunk(this->_request->request(), NULL, 0);
+}
+
+esp_err_t PsychicResponse::redirect(const char* url)
+{
+  if (!_code)
+    setCode(301);
+  addHeader("Location", url);
+  return send();
+}
+
+esp_err_t PsychicResponse::send(int code)
+{
+  setCode(code);
+  return send();
+}
+
+esp_err_t PsychicResponse::send(const char* content)
+{
+  if (!_code)
+    setCode(200);
+  if (_contentType.isEmpty())
+    setContentType("text/html");
+  setContent(content);
+  return send();
+}
+
+esp_err_t PsychicResponse::send(const char* contentType, const char* content)
+{
+  if (!_code)
+    setCode(200);
+  setContentType(contentType);
+  setContent(content);
+  return send();
+}
+
+esp_err_t PsychicResponse::send(int code, const char* contentType, const char* content)
+{
+  setCode(code);
+  setContentType(contentType);
+  setContent(content);
+  return send();
+}
+
+esp_err_t PsychicResponse::send(int code, const char* contentType, const uint8_t* content, size_t len)
+{
+  setCode(code);
+  setContentType(contentType);
+  setContent(content, len);
+  return send();
+}
+
+esp_err_t PsychicResponse::error(httpd_err_code_t code, const char* message)
+{
+  return httpd_resp_send_err(_request->_req, code, message);
+}
+
+httpd_req_t* PsychicResponse::request()
+{
+  return _request->_req;
 }

--- a/src/PsychicResponse.h
+++ b/src/PsychicResponse.h
@@ -14,6 +14,7 @@ class PsychicResponse
     int _code;
     char _status[60];
     std::list<HTTPHeader> _headers;
+    String _contentType;
     int64_t _contentLength;
     const char* _body;
 
@@ -24,6 +25,8 @@ class PsychicResponse
     void setCode(int code);
 
     void setContentType(const char* contentType);
+    String& getContentType() { return _contentType; }
+
     void setContentLength(int64_t contentLength) { _contentLength = contentLength; }
     int64_t getContentLength(int64_t contentLength) { return _contentLength; }
 
@@ -41,6 +44,60 @@ class PsychicResponse
     void sendHeaders();
     esp_err_t sendChunk(uint8_t* chunk, size_t chunksize);
     esp_err_t finishChunking();
+
+    esp_err_t redirect(const char* url);
+    esp_err_t send(int code);
+    esp_err_t send(const char* content);
+    esp_err_t send(const char* contentType, const char* content);
+    esp_err_t send(int code, const char* contentType, const char* content);
+    esp_err_t send(int code, const char* contentType, const uint8_t* content, size_t len);
+    esp_err_t error(httpd_err_code_t code, const char* message);
+
+    httpd_req_t* request();
+};
+
+class PsychicResponseDelegate
+{
+  protected:
+    PsychicResponse* _response;
+
+  public:
+    PsychicResponseDelegate(PsychicResponse* response) : _response(response) {}
+    virtual ~PsychicResponseDelegate() {}
+
+    void setCode(int code) { _response->setCode(code); }
+
+    void setContentType(const char* contentType) { _response->setContentType(contentType); }
+    String& getContentType() { return _response->getContentType(); }
+
+    void setContentLength(int64_t contentLength) { _response->setContentLength(contentLength); }
+    int64_t getContentLength(int64_t contentLength) { return _response->getContentLength(); }
+
+    void addHeader(const char* field, const char* value) { _response->addHeader(field, value); }
+
+    void setCookie(const char* key, const char* value, unsigned long max_age = 60 * 60 * 24 * 30, const char* extras = "") { _response->setCookie(key, value, max_age, extras); }
+
+    void setContent(const char* content) { _response->setContent(content); }
+    void setContent(const uint8_t* content, size_t len) { _response->setContent(content, len); }
+
+    const char* getContent() { return _response->getContent(); }
+    size_t getContentLength() { return _response->getContentLength(); }
+
+    esp_err_t send() { return _response->send(); }
+    void sendHeaders() { _response->sendHeaders(); }
+
+    esp_err_t sendChunk(uint8_t* chunk, size_t chunksize) { return _response->sendChunk(chunk, chunksize); }
+    esp_err_t finishChunking() { return _response->finishChunking(); }
+
+    esp_err_t redirect(const char* url) { return _response->redirect(url); }
+    esp_err_t send(int code) { return _response->send(code); }
+    esp_err_t send(const char* content) { return _response->send(content); }
+    esp_err_t send(const char* contentType, const char* content) { return _response->send(contentType, content); }
+    esp_err_t send(int code, const char* contentType, const char* content) { return _response->send(code, contentType, content); }
+    esp_err_t send(int code, const char* contentType, const uint8_t* content, size_t len) { return _response->send(code, contentType, content, len); }
+    esp_err_t error(httpd_err_code_t code, const char* message) { return _response->error(code, message); }
+
+    httpd_req_t* request() { return _response->request(); }
 };
 
 #endif // PsychicResponse_h

--- a/src/PsychicStaticFileHandler.h
+++ b/src/PsychicStaticFileHandler.h
@@ -33,7 +33,7 @@ class PsychicStaticFileHandler : public PsychicWebHandler
   public:
     PsychicStaticFileHandler(const char* uri, FS& fs, const char* path, const char* cache_control);
     bool canHandle(PsychicRequest* request) override;
-    esp_err_t handleRequest(PsychicRequest* request) override;
+    esp_err_t handleRequest(PsychicRequest* request, PsychicResponse* response) override;
     PsychicStaticFileHandler* setIsDir(bool isDir);
     PsychicStaticFileHandler* setDefaultFile(const char* filename);
     PsychicStaticFileHandler* setCacheControl(const char* cache_control);

--- a/src/PsychicStreamResponse.h
+++ b/src/PsychicStreamResponse.h
@@ -7,15 +7,15 @@
 
 class PsychicRequest;
 
-class PsychicStreamResponse : public PsychicResponse, public Print
+class PsychicStreamResponse : public PsychicResponseDelegate, public Print
 {
   private:
     ChunkPrinter* _printer;
     uint8_t* _buffer;
 
   public:
-    PsychicStreamResponse(PsychicRequest* request, const String& contentType);
-    PsychicStreamResponse(PsychicRequest* request, const String& contentType, const String& name); // Download
+    PsychicStreamResponse(PsychicResponse* response, const String& contentType);
+    PsychicStreamResponse(PsychicResponse* response, const String& contentType, const String& name); // Download
 
     ~PsychicStreamResponse();
 

--- a/src/PsychicUploadHandler.h
+++ b/src/PsychicUploadHandler.h
@@ -24,7 +24,7 @@ class PsychicUploadHandler : public PsychicWebHandler
     ~PsychicUploadHandler();
 
     bool canHandle(PsychicRequest* request) override;
-    esp_err_t handleRequest(PsychicRequest* request) override;
+    esp_err_t handleRequest(PsychicRequest* request, PsychicResponse* response) override;
 
     PsychicUploadHandler* onUpload(PsychicUploadCallback fn);
 };

--- a/src/PsychicWebHandler.cpp
+++ b/src/PsychicWebHandler.cpp
@@ -13,7 +13,7 @@ bool PsychicWebHandler::canHandle(PsychicRequest* request)
   return true;
 }
 
-esp_err_t PsychicWebHandler::handleRequest(PsychicRequest* request)
+esp_err_t PsychicWebHandler::handleRequest(PsychicRequest* request, PsychicResponse* response)
 {
   // lookup our client
   PsychicClient* client = checkForNewClient(request->client());
@@ -28,7 +28,7 @@ esp_err_t PsychicWebHandler::handleRequest(PsychicRequest* request)
     /* Respond with 400 Bad Request */
     char error[60];
     sprintf(error, "Request body must be less than %lu bytes!", request->server()->maxRequestBodySize);
-    request->reply(400, "text/html", error);
+    response->send(400, "text/html", error);
 
     /* Return failure to close underlying connection else the incoming file content will keep the socket busy */
     return ESP_FAIL;
@@ -37,14 +37,14 @@ esp_err_t PsychicWebHandler::handleRequest(PsychicRequest* request)
   // get our body loaded up.
   esp_err_t err = request->loadBody();
   if (err != ESP_OK)
-    return request->reply(400, "text/html", "Error loading request body.");
+    return response->send(400, "text/html", "Error loading request body.");
 
   // load our params in.
   request->loadParams();
 
   // okay, pass on to our callback.
   if (this->_requestCallback != NULL)
-    err = this->_requestCallback(request);
+    err = this->_requestCallback(request, response);
 
   return err;
 }

--- a/src/PsychicWebHandler.h
+++ b/src/PsychicWebHandler.h
@@ -22,7 +22,7 @@ class PsychicWebHandler : public PsychicHandler
     ~PsychicWebHandler();
 
     virtual bool canHandle(PsychicRequest* request) override;
-    virtual esp_err_t handleRequest(PsychicRequest* request) override;
+    virtual esp_err_t handleRequest(PsychicRequest* request, PsychicResponse* response) override;
     PsychicWebHandler* onRequest(PsychicHttpRequestCallback fn);
 
     virtual void openCallback(PsychicClient* client);

--- a/src/PsychicWebSocket.cpp
+++ b/src/PsychicWebSocket.cpp
@@ -181,7 +181,7 @@ void PsychicWebSocketHandler::closeCallback(PsychicClient* client)
 
 bool PsychicWebSocketHandler::isWebSocket() { return true; }
 
-esp_err_t PsychicWebSocketHandler::handleRequest(PsychicRequest* request)
+esp_err_t PsychicWebSocketHandler::handleRequest(PsychicRequest* request, PsychicResponse* response)
 {
   // lookup our client
   PsychicClient* client = checkForNewClient(request->client());

--- a/src/PsychicWebSocket.h
+++ b/src/PsychicWebSocket.h
@@ -60,7 +60,7 @@ class PsychicWebSocketHandler : public PsychicHandler
     void closeCallback(PsychicClient* client) override;
 
     bool isWebSocket() override final;
-    esp_err_t handleRequest(PsychicRequest* request) override;
+    esp_err_t handleRequest(PsychicRequest* request, PsychicResponse* response) override;
 
     PsychicWebSocketHandler* onOpen(PsychicWebSocketClientCallback fn);
     PsychicWebSocketHandler* onFrame(PsychicWebSocketFrameCallback fn);


### PR DESCRIPTION
@hoeken : as explained in DIscord: these changes complete what should be a complete middlware handling. 

there were some missing pieces left over that I've fixed or completed.

- filter chain (object should be stateless) - changing to a function - this is also faster

- response is not anymore in the handle method which is problematic because any middleware such as CSRF token acting on the reponse headers won't work

- delegate => I see where you struggled (event source is a good use case) => worked on a proposal

- repsonse oject creation: the only place a response is created should be in pysichic, before calling the middleware.  this is not ok to create a response from within a handler because the response object is not processed by the middleware

- api changes: moved response method in response object

- Added `PsychicMiddlewares.h` to add a list of proposed middleware

- Refactored authentication: no more duplication of username user/pass in all handlers since authc is now a middleware

## Current state

- compiles with the platform io example

- Will let you check the changes - you can either grab the commit, modify, push, do whatever you want, if you are OK with the changes I can also push them to a more clean state

I didn't test yet: just did api changes, which compiles on PIO.
Waiting for your feedback before continuing.
Let me know your quesiton / comments about the changes! :-)