### PR TITLE
Fixed recursive send bug. Now files can be sent even if they are smaller then the FILE_CHUNK_SIZE

### DIFF
--- a/src/PsychicFileResponse.cpp
+++ b/src/PsychicFileResponse.cpp
@@ -131,7 +131,7 @@ esp_err_t PsychicFileResponse::send()
     size_t readSize = _content.readBytes((char*)buffer, size);
 
     setContent(buffer, readSize);
-    err = send();
+    err = _response->send();
 
     free(buffer);
   } else {


### PR DESCRIPTION
from `err = send();` to `err = _response->send();`