### PR TITLE
Fixed CORS on regular requests. Added OPTIONS endpoint support

### DIFF
--- a/src/PsychicHttpServer.h
+++ b/src/PsychicHttpServer.h
@@ -49,7 +49,14 @@ class PsychicHttpServer
     virtual ~PsychicHttpServer();
 
     // what methods to support
-    std::list<http_method> supported_methods = {HTTP_GET, HTTP_POST, HTTP_DELETE, HTTP_HEAD, HTTP_PUT};
+    std::list<http_method> supported_methods = {
+      HTTP_GET,
+      HTTP_POST,
+      HTTP_DELETE,
+      HTTP_HEAD,
+      HTTP_PUT,
+      HTTP_OPTIONS
+    };
 
     // esp-idf specific stuff
     httpd_handle_t server;

--- a/src/PsychicHttpsServer.h
+++ b/src/PsychicHttpsServer.h
@@ -36,5 +36,5 @@ class PsychicHttpsServer : public PsychicHttpServer
 #endif // PsychicHttpsServer_h
 
 #else
-  #error ESP-IDF https server support not enabled.
+  #warning ESP-IDF https server support not enabled.
 #endif // CONFIG_ESP_HTTPS_SERVER_ENABLE

--- a/src/PsychicMiddlewares.h
+++ b/src/PsychicMiddlewares.h
@@ -141,12 +141,12 @@ class CorsMiddleware : public PsychicMiddleware
 
     esp_err_t run(PsychicRequest* request, PsychicResponse* response, PsychicMiddlewareCallback next) override
     {
+      response->addHeader("Access-Control-Allow-Origin", _origin.c_str());
+      response->addHeader("Access-Control-Allow-Methods", _methods.c_str());
+      response->addHeader("Access-Control-Allow-Headers", _headers.c_str());
+      response->addHeader("Access-Control-Allow-Credentials", _credentials ? "true" : "false");
+      response->addHeader("Access-Control-Max-Age", String(_maxAge).c_str());
       if (request->method() == HTTP_OPTIONS && request->hasHeader("Origin")) {
-        response->addHeader("Access-Control-Allow-Origin", _origin.c_str());
-        response->addHeader("Access-Control-Allow-Methods", _methods.c_str());
-        response->addHeader("Access-Control-Allow-Headers", _headers.c_str());
-        response->addHeader("Access-Control-Allow-Credentials", _credentials ? "true" : "false");
-        response->addHeader("Access-Control-Max-Age", String(_maxAge).c_str());
         return response->send(200);
       }
       return next(request, response);


### PR DESCRIPTION
- Added `HTTP_OPTIONS` to the `supported_methods` list.
- Send CORS headers on every response. It is required on not just the preflight requests but on every request. ( does not fix SSE CORS problem )
- Fixed HTTPS server error. Changed it to warning if not enabled.