### PR TITLE
Fixing PsychicHttpsServer SSL setup

### DIFF
--- a/src/PsychicHttpsServer.cpp
+++ b/src/PsychicHttpsServer.cpp
@@ -2,7 +2,7 @@
 
 #ifdef CONFIG_ESP_HTTPS_SERVER_ENABLE
 
-PsychicHttpsServer::PsychicHttpsServer(uint16_t port, const char* cert, const char* private_key) : PsychicHttpServer(port)
+PsychicHttpsServer::PsychicHttpsServer(uint16_t port) : PsychicHttpServer(port)
 {
   // for a SSL server
   ssl_config = HTTPD_SSL_CONFIG_DEFAULT();
@@ -20,7 +20,6 @@ PsychicHttpsServer::PsychicHttpsServer(uint16_t port, const char* cert, const ch
   ssl_config.httpd.max_open_sockets = 2;
 
   setPort(port);
-  setCertificate(cert, private_key);
 }
 
 PsychicHttpsServer::~PsychicHttpsServer() {}
@@ -30,23 +29,21 @@ void PsychicHttpsServer::setPort(uint16_t port)
   this->ssl_config.port_secure = port;
 }
 
-void PsychicHttpsServer::setCertificate(const char* cert, const char* private_key)
+void PsychicHttpsServer::setCertificate(const uint8_t* cert, size_t cert_size, const uint8_t* private_key, size_t private_key_size)
 {
-  if (cert)
-  {
+  if (cert) {
   #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 2)
-    this->ssl_config.servercert = (uint8_t*)cert;
-    this->ssl_config.servercert_len = strlen(cert) + 1;
+    this->ssl_config.servercert = cert;
+    this->ssl_config.servercert_len = cert_size;
   #else
-    this->ssl_config.cacert_pem = (uint8_t*)cert;
-    this->ssl_config.cacert_len = strlen(cert) + 1;
+    this->ssl_config.cacert_pem = cert;
+    this->ssl_config.cacert_len = cert_size;
   #endif
   }
 
-  if (private_key)
-  {
-    this->ssl_config.prvtkey_pem = (uint8_t*)private_key;
-    this->ssl_config.prvtkey_len = strlen(private_key) + 1;
+  if (private_key) {
+    this->ssl_config.prvtkey_pem = private_key;
+    this->ssl_config.prvtkey_len = private_key_size;
   }
 }
 

--- a/src/PsychicHttpsServer.h
+++ b/src/PsychicHttpsServer.h
@@ -1,20 +1,20 @@
 #ifndef PsychicHttpsServer_h
-#define PsychicHttpsServer_h
+  #define PsychicHttpsServer_h
 
-#include <sdkconfig.h>
+  #include <sdkconfig.h>
 
-#ifdef CONFIG_ESP_HTTPS_SERVER_ENABLE
+  #ifdef CONFIG_ESP_HTTPS_SERVER_ENABLE
 
-  #include "PsychicCore.h"
-  #include "PsychicHttpServer.h"
-  #include <esp_https_server.h>
-  #if !CONFIG_HTTPD_WS_SUPPORT
-    #error PsychicHttpsServer cannot be used unless HTTPD_WS_SUPPORT is enabled in esp-http-server component configuration
-  #endif
+    #include "PsychicCore.h"
+    #include "PsychicHttpServer.h"
+    #include <esp_https_server.h>
+    #if !CONFIG_HTTPD_WS_SUPPORT
+      #error PsychicHttpsServer cannot be used unless HTTPD_WS_SUPPORT is enabled in esp-http-server component configuration
+    #endif
 
-  #ifndef PSY_ENABLE_SSL
-    #define PSY_ENABLE_SSL // you can use this define in your code to enable/disable these features
-  #endif
+    #ifndef PSY_ENABLE_SSL
+      #define PSY_ENABLE_SSL // you can use this define in your code to enable/disable these features
+    #endif
 
 class PsychicHttpsServer : public PsychicHttpServer
 {
@@ -23,17 +23,20 @@ class PsychicHttpsServer : public PsychicHttpServer
     virtual esp_err_t _stopServer() override final;
 
   public:
-    PsychicHttpsServer(uint16_t port = 443, const char* cert = nullptr, const char* private_key = nullptr);
+    PsychicHttpsServer(uint16_t port = 443);
     ~PsychicHttpsServer();
 
     httpd_ssl_config_t ssl_config;
 
     // using PsychicHttpServer::listen; // keep the regular version
     virtual void setPort(uint16_t port) override final;
-    void setCertificate(const char* cert, const char* private_key);
+    // Pointer to certificate data in PEM format
+    void setCertificate(const char* cert, const char* private_key = nullptr) { setCertificate((const uint8_t*)cert, strlen(cert) + 1, (const uint8_t*)private_key, private_key ? strlen(private_key) + 1 : 0); }
+    // Pointer to certificate data in PEM or DER format. PEM-format must have a terminating NULL-character. DER-format requires the length to be passed in certSize and keySize.
+    void setCertificate(const uint8_t* cert, size_t cert_size, const uint8_t* private_key = nullptr, size_t private_key_size = 0);
 };
 
-#endif // PsychicHttpsServer_h
+  #endif // PsychicHttpsServer_h
 
 #else
   #warning ESP-IDF https server support not enabled.


### PR DESCRIPTION
SSL can be setup in 2 ways: PEM or DER: EM-format must have a terminating NULL-character. DER-format requires the length to be passed in certSize and keySize.

- removed ssl setup from constructor
- added overloads for `PsychicHttpsServer.setCertificate()` to support PER and DER
