### PR TITLE
Don't die when file is empty

### DIFF
--- a/src/PsychicFileResponse.cpp
+++ b/src/PsychicFileResponse.cpp
@@ -104,7 +104,7 @@ esp_err_t PsychicFileResponse::send()
   if (size < FILE_CHUNK_SIZE)
   {
     uint8_t *buffer = (uint8_t *)malloc(size);
-    if (buffer == NULL)
+    if (buffer == NULL && size > 0)
     {
       /* Respond with 500 Internal Server Error */
       httpd_resp_send_err(this->_request->request(), HTTPD_500_INTERNAL_SERVER_ERROR, "Unable to allocate memory.");


### PR DESCRIPTION
When a requested file is actually empty the server will throw an error 500.
This PR fixes this.

In my case, I'm using a vue app which generates empty chunks, and when the website tries to load those it fails and doesn't continue to load anything else.