### PR TITLE
Update statuscode handling in PsychicResponse.cpp

### DIFF
--- a/src/PsychicResponse.cpp
+++ b/src/PsychicResponse.cpp
@@ -99,10 +99,6 @@ size_t PsychicResponse::getContentLength()
 
 esp_err_t PsychicResponse::send()
 {
-  //esp-idf makes you set the whole status.
-  sprintf(_status, "%u %s", _code, http_status_reason(_code));
-  httpd_resp_set_status(_request->request(), _status);
-
   //our headers too
   this->sendHeaders();
 
@@ -118,6 +114,10 @@ esp_err_t PsychicResponse::send()
 
 void PsychicResponse::sendHeaders()
 {
+  //esp-idf makes you set the whole status.
+  sprintf(_status, "%u %s", _code, http_status_reason(_code));
+  httpd_resp_set_status(_request->request(), _status);
+  
   //get our global headers out of the way first
   for (HTTPHeader header : DefaultHeaders::Instance().getHeaders())
     httpd_resp_set_hdr(_request->request(), header.field, header.value);


### PR DESCRIPTION
Moved status code sending to `sendHeaders()`. Therefore all derived instances do not need to manually send (or forget to send).

As mentioned in #219 `PsychicStreamResponse` only calls [`sendHeaders()`](https://github.com/hoeken/PsychicHttp/blob/725f415a1352f86a3d47a94aee8ef9eec8aa2127/src/PsychicStreamResponse.cpp#L47).

Additionally, this fix would also rectify a (possibly) unreported bug in `PsychicFileResponse`. When sending a non-chunked file, it will correctly send the status code via `send()`:

https://github.com/hoeken/PsychicHttp/blob/725f415a1352f86a3d47a94aee8ef9eec8aa2127/src/PsychicFileResponse.cpp#L117

However, if sending chunked the status code is never sent (exactly the same issues as `PsychicStreamResponse` only calling [`sendHeaders()`](https://github.com/hoeken/PsychicHttp/blob/725f415a1352f86a3d47a94aee8ef9eec8aa2127/src/PsychicStreamResponse.cpp#L47))

https://github.com/hoeken/PsychicHttp/blob/725f415a1352f86a3d47a94aee8ef9eec8aa2127/src/PsychicFileResponse.cpp#L121-L132

