### PR TITLE
esp_netif interfaces check for isConnected for esp32p4 compatiblity

### DIFF
--- a/src/PsychicHttpServer.cpp
+++ b/src/PsychicHttpServer.cpp
@@ -112,7 +112,7 @@ esp_err_t PsychicHttpServer::start()
 
   // starting without network will crash us
   // isConnected() now checks all network interfaces including co-processor connections
-  if (!skipNetworkCheck && !isConnected()) {
+  if (!isConnected()) {
     ESP_LOGE(PH_TAG, "Server start failed - no network interface available.");
     return ESP_FAIL;
   }

--- a/src/PsychicHttpServer.cpp
+++ b/src/PsychicHttpServer.cpp
@@ -6,6 +6,7 @@
 #include "PsychicWebHandler.h"
 #include "PsychicWebSocket.h"
 #include "WiFi.h"
+#include "esp_netif.h"
 #ifdef PSY_ENABLE_ETHERNET
   #include "ETH.h"
 #endif
@@ -84,16 +85,23 @@ uint16_t PsychicHttpServer::getPort()
 
 bool PsychicHttpServer::isConnected()
 {
-  if (WiFi.softAPIP())
-    return true;
-  if (WiFi.localIP())
-    return true;
+  // Use esp_netif API to enumerate all network interfaces
+  // This works universally across all ESP32 variants including P4 with co-processor WiFi/Ethernet
+  esp_netif_t* netif = esp_netif_next(NULL);
+  while (netif != NULL) {
+    if (esp_netif_is_netif_up(netif)) {
+      esp_netif_ip_info_t ip_info;
+      if (esp_netif_get_ip_info(netif, &ip_info) == ESP_OK && ip_info.ip.addr != 0) {
+        const char* desc = esp_netif_get_desc(netif);
+        ESP_LOGD(PH_TAG, "Network connected via interface: %s (IP: " IPSTR ")", 
+                 desc ? desc : "unknown", IP2STR(&ip_info.ip));
+        return true;
+      }
+    }
+    netif = esp_netif_next(netif);
+  }
 
-#ifdef PSY_ENABLE_ETHERNET
-  if (ETH.localIP())
-    return true;
-#endif
-
+  ESP_LOGD(PH_TAG, "No active network interfaces found");
   return false;
 }
 
@@ -102,9 +110,10 @@ esp_err_t PsychicHttpServer::start()
   if (_running)
     return ESP_OK;
 
-  // starting without network will crash us.
-  if (!isConnected()) {
-    ESP_LOGE(PH_TAG, "Server start failed - no network.");
+  // starting without network will crash us
+  // isConnected() now checks all network interfaces including co-processor connections
+  if (!skipNetworkCheck && !isConnected()) {
+    ESP_LOGE(PH_TAG, "Server start failed - no network interface available.");
     return ESP_FAIL;
   }
 


### PR DESCRIPTION
Hi,

i hope this contribution is up to standarts, its my first time so sorry for in advance if not suited. 

On a esp32p4 model with co-processor the webserver didnt start because we dont use WiFi or ETH in esp-idf. I tried different things to fix that problem and this pr is what i came up with. 

It doesnt rely on WiFi or ETH, instead loops through the interfaces to find a used one. 

Feedback is highly appreciated. 

Best
Adrian