### PR TITLE
Fix PsychicJsonResponse when using ArduinoJson v6

### DIFF
--- a/src/PsychicJson.cpp
+++ b/src/PsychicJson.cpp
@@ -1,7 +1,7 @@
 #include "PsychicJson.h"
 
 #ifdef ARDUINOJSON_6_COMPATIBILITY
-PsychicJsonResponse::PsychicJsonResponse(PsychicResponse* response, bool isArray, size_t maxJsonBufferSize) : __response(response),
+PsychicJsonResponse::PsychicJsonResponse(PsychicResponse* response, bool isArray, size_t maxJsonBufferSize) : PsychicResponseDelegate(response),
                                                                                                               _jsonBuffer(maxJsonBufferSize)
 {
   response->setContentType(JSON_MIMETYPE);


### PR DESCRIPTION
As mentioned in issue #211 there's a problem when compiling against ArduinoJson v6. This fixed it for me.